### PR TITLE
docs: add focused contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## What changed?
+
+<!-- Explain the problem and your solution in plain language. -->
+
+## Scope
+
+<!-- One feature or fix per PR. Link any related issue or prior PR. -->
+
+- [ ] This PR contains one focused feature or fix.
+- [ ] I started from the latest `main` branch.
+- [ ] I discussed this change with a maintainer first if it exceeds 1,000 human-written lines or 20 source, test, or documentation files.
+- [ ] I kept unrelated refactors, dependency migrations, runtime upgrades, and UI changes out of this PR.
+- [ ] I did not edit or commit generated `dist/` files.
+
+## Validation
+
+<!-- List manual tests, providers, operating systems, and edge cases you checked. -->
+
+- [ ] I added or updated focused tests.
+- [ ] `npm run typecheck` passes.
+- [ ] `npm test` passes.
+- [ ] `npm run build` passes.
+- [ ] I updated user-facing documentation where needed.
+- [ ] I included screenshots for visible UI changes, or the change has no visible UI.
+
+## Risks and limitations
+
+<!-- Describe compatibility concerns, security implications, and anything not yet tested. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Relay AI
+
+Thanks for taking the time to improve Relay AI. Focused pull requests are much easier to review, test, and merge, so please follow these guidelines before submitting changes.
+
+## Before you start
+
+- Search existing issues and pull requests for related work.
+- Start from the latest `main` branch.
+- Open an issue before beginning security-sensitive work involving authentication, credentials, proxies, networking, or modifications to installed third-party applications.
+- Ask for maintainer agreement before starting a change expected to exceed 1,000 human-written lines or 20 source, test, or documentation files. Generated files and lockfiles do not count toward these numbers.
+
+## Keep each pull request focused
+
+- Submit one feature or fix per pull request.
+- Do not bundle unrelated refactors, dependency migrations, UI work, or runtime upgrades with a feature.
+- Split independent changes into separate pull requests, even when they were developed on the same branch.
+- If a reviewer cannot test or revert a change independently, it probably belongs in a separate pull request.
+
+Maintainers may close an oversized or mixed-scope pull request and ask for smaller submissions. This is about giving each contribution a fair and timely review, not rejecting the underlying ideas.
+
+## Generated files
+
+Do not edit or commit `dist/` files in a contributor pull request. Maintainers will regenerate release bundles from the accepted source changes.
+
+Commit dependency lockfile changes only when the pull request intentionally changes dependencies.
+
+## Quality requirements
+
+Before submitting:
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run build
+```
+
+Your pull request should include:
+
+- A plain-language explanation of the problem and the proposed change.
+- Focused tests for new behavior and bug fixes.
+- Any user-facing documentation affected by the change.
+- Known limitations, compatibility concerns, and security implications.
+- Screenshots for visible UI changes.
+
+Please preserve authorship and link the original issue or pull request when adapting another contributor's work.
+
+## Review expectations
+
+Reviewers may ask you to reduce scope, rebase onto current `main`, add tests, or separate risky platform changes from user-facing features. Address those requests in the same focused branch without adding unrelated work.
+
+Thank you for helping make Relay AI better.

--- a/README.md
+++ b/README.md
@@ -570,7 +570,9 @@ The deprecated `OPENCODE_STARTER_HOME` env var still works as a fallback for `RE
 
 ## Contributing
 
-Private beta right now. Issues and PRs welcome on GitHub.
+Private beta right now. Issues and focused PRs are welcome on GitHub.
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before starting. Submit one feature or fix per PR, and discuss large or security-sensitive changes with a maintainer first.
 
 ## Support
 


### PR DESCRIPTION
## Summary

Adds clear contribution guidelines and a pull request template so contributors know the expected scope before submitting work.

## Why

Relay AI needs focused pull requests that maintainers can review, test, and revert independently. Large submissions that combine unrelated features, migrations, UI changes, and generated bundles consume significant review time and make safe integration difficult.

## What changed

- Adds `CONTRIBUTING.md` with scope, size, testing, attribution, and generated-file rules.
- Asks contributors to discuss changes above 1,000 human-written lines or 20 source, test, or documentation files before starting.
- Requires one feature or fix per pull request.
- Adds a GitHub pull request checklist.
- Links the policy from the README.

The policy remains welcoming and explains that requests to split a PR are about giving each contribution a fair review.

## Validation

- Build passed.
- Type-checking passed.
- 104 test files and 1,028 tests passed.
- The generated `dist/` tree remained unchanged.
