### PR TITLE
fix(claude): exit gracefully without a TTY instead of crashing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import { refreshModelsDevCacheAsync } from './registry/models-dev.js';
 import { setAgentStdoutMode, isAgentStdoutMode } from './agent-io.js';
 import {
   findProviderAndModel,
+  launchAllowsNonTty,
   normalizeClaudeAgentArgs,
   planLaunchWizard,
   wantsCleanAgentStdout,
@@ -1119,6 +1120,19 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
     return 1;
   }
   const switchMenuActive = favorites.length > 0 && !launchPlan.skip;
+
+  // Without a resolved target (boot flags / print-mode prefs) or the http-proxy
+  // bypass, the launch would open the interactive wizard. Bail early with a
+  // friendly message when there is no TTY, instead of crashing inside clack with
+  // an opaque ERR_TTY_INIT_FAILED. Mirrors the guard in codex.ts.
+  if (!launchAllowsNonTty(launchPlan, httpProxyOnly) && !process.stdin.isTTY) {
+    console.error(
+      pc.red(
+        'relay-ai claude requires an interactive terminal (or use --provider and --model for non-interactive launch).',
+      ),
+    );
+    return 1;
+  }
 
   if (!agentStdout) relayIntro('Claude Code');
 

--- a/src/launch-target.ts
+++ b/src/launch-target.ts
@@ -197,6 +197,18 @@ export function planLaunchWizard(opts: {
   return { skip: false, target: null };
 }
 
+/**
+ * Whether a launch may proceed without an interactive terminal. True when a
+ * target was already resolved from boot flags or print-mode preferences (so the
+ * wizard is skipped), or when the caller bypasses the wizard entirely (e.g.
+ * Claude `--http-proxy` with no explicit model). When this is false and there is
+ * no TTY, callers should exit with a friendly error instead of crashing inside
+ * the interactive prompt.
+ */
+export function launchAllowsNonTty(plan: LaunchWizardPlan, bypassWizard = false): boolean {
+  return bypassWizard || !!(plan.skip && plan.target);
+}
+
 function nonInteractiveLaunchError(agent: 'claude' | 'codex' | 'gemini' | 'antigravity'): string {
   if (agent === 'claude') return 'Print mode requires --provider and --model, or saved preferences from a prior launch.';
   if (agent === 'codex') return 'Non-interactive Codex launch requires --provider and --model, or saved preferences from a prior launch.';

--- a/tests/launch-target.test.ts
+++ b/tests/launch-target.test.ts
@@ -6,6 +6,7 @@ import {
   isClaudePrintMode,
   isCodexMachineReadableOutput,
   isCodexNonInteractive,
+  launchAllowsNonTty,
   normalizeClaudeAgentArgs,
   parseModelSlug,
   planLaunchWizard,
@@ -112,5 +113,24 @@ describe('launch-target', () => {
   it('adds --verbose for claude stream-json print mode', () => {
     expect(normalizeClaudeAgentArgs(['-p', 'hi', '--output-format', 'stream-json'])).toContain('--verbose');
     expect(normalizeClaudeAgentArgs(['-p', 'hi', '--output-format', 'json'])).not.toContain('--verbose');
+  });
+
+  describe('launchAllowsNonTty', () => {
+    it('allows a launch when boot flags resolved a target', () => {
+      expect(launchAllowsNonTty({ skip: true, target: { providerId: 'go', modelId: 'kimi-k3' } })).toBe(true);
+    });
+
+    it('disallows a launch that would open the interactive wizard', () => {
+      expect(launchAllowsNonTty({ skip: false, target: null })).toBe(false);
+    });
+
+    it('disallows when skip is set but no target was resolved', () => {
+      expect(launchAllowsNonTty({ skip: true, target: null })).toBe(false);
+    });
+
+    it('allows when the caller bypasses the wizard (e.g. http-proxy)', () => {
+      expect(launchAllowsNonTty({ skip: true, target: null }, true)).toBe(true);
+      expect(launchAllowsNonTty({ skip: false, target: null }, true)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Problem

When `relay-ai claude` is launched without a resolved target (no `--provider`/`--model` boot flags, no print-mode preferences) and without the `--http-proxy` bypass, it falls through to the interactive provider/model wizard. In an environment with no TTY (CI, pipes, agent harnesses), that wizard crashes deep inside `clack` with an opaque `ERR_TTY_INIT_FAILED`.

## Change

- Add `launchAllowsNonTty(plan, bypassWizard)` in `src/launch-target.ts`.
- In `runClaudeCommand` (`src/cli.ts`), when a launch would require the wizard and `process.stdin.isTTY` is false, exit early (code 1) with a clear message: *"relay-ai claude requires an interactive terminal (or use --provider and --model for non-interactive launch)."*

This mirrors the existing non-TTY guard in the Codex path.

## Tests

Adds `tests/launch-target.test.ts` covering `launchAllowsNonTty` for the resolved-target, wizard-bypass, and wizard-required cases.

## Limitations / notes

Pure guard-and-exit. No behavior change when a TTY is present, or when boot flags / saved preferences already resolve a target.
