### PR TITLE
fix(build): make the UI-asset copy step cross-platform (Windows)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsup && mkdir -p dist/ui/public && cp -r src/ui/public/. dist/ui/public/",
+    "build": "tsup && node scripts/copy-ui-assets.mjs",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/copy-ui-assets.mjs
+++ b/scripts/copy-ui-assets.mjs
@@ -1,0 +1,17 @@
+// Copy static UI assets into dist/ after the tsup build.
+//
+// Cross-platform replacement for the shell one-liner
+//   mkdir -p dist/ui/public && cp -r src/ui/public/. dist/ui/public/
+// which fails on Windows because npm runs scripts through cmd.exe, where
+// `mkdir -p` and `cp` do not exist ("The syntax of the command is incorrect").
+// fs.cpSync creates the destination tree itself, so no separate mkdir is needed.
+
+import { cpSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const src = join(root, 'src', 'ui', 'public');
+const dest = join(root, 'dist', 'ui', 'public');
+
+cpSync(src, dest, { recursive: true });


### PR DESCRIPTION
## Problem

The `build` script used a POSIX shell one-liner:

```
tsup && mkdir -p dist/ui/public && cp -r src/ui/public/. dist/ui/public/
```

On Windows, npm runs scripts through `cmd.exe`, where `mkdir -p` and `cp` don't exist, so `npm run build` fails with *"The syntax of the command is incorrect."*

## Change

Replace the shell copy with `node scripts/copy-ui-assets.mjs`, a small cross-platform script using `fs.cpSync(src, dest, { recursive: true })` — which creates the destination tree itself, so no separate `mkdir` step is needed.

## Tests

Build-tooling change (no unit test). Verified `npm run build` now succeeds on Windows and still produces `dist/ui/public`; output is unchanged on macOS/Linux.

## Limitations / notes

Behavior is identical to the previous copy on POSIX platforms.
