### PR TITLE
fix(claude-app): detect Claude Desktop in its AnthropicClaude install folder (Windows)

### DIFF
--- a/src/claude-desktop/app-launch.ts
+++ b/src/claude-desktop/app-launch.ts
@@ -34,6 +34,8 @@ function winLocalAppData(): string {
 function winClaudeExeCandidates(): string[] {
   const local = winLocalAppData();
   const bases = [
+    // Squirrel install folder used by the Anthropic Claude desktop installer.
+    join(local, 'AnthropicClaude'),
     join(local, 'Programs', 'Claude'),
     join(local, 'Claude'),
   ];


### PR DESCRIPTION
## Problem

On Windows, the Anthropic Claude desktop installer (Squirrel) installs into `%LOCALAPPDATA%\AnthropicClaude`. `winClaudeExeCandidates()` didn't check that location, so `relay-ai claude-app` failed to find an installed Claude Desktop even when it was present.

## Change

Add `join(local, 'AnthropicClaude')` to the candidate base paths, alongside the existing `Programs\Claude` and `Claude` locations.

## Tests

Covered by the existing claude-app config/launch tests; the change is a single static path candidate.

## Limitations / notes

Additive only — a hardcoded, known install location. No input handling changes.
