### PR TITLE
fix(launch): escape spawn args for cmd.exe on Windows

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -48,6 +48,22 @@ export function buildClaudeArgs(model: string | undefined, extraArgs: string[]):
   return model ? ['--model', model, ...extraArgs] : [...extraArgs];
 }
 
+/**
+ * Node's child_process.spawn does NOT escape arguments when { shell: true } is
+ * used (documented Node behavior) — cmd.exe re-tokenizes the command line on
+ * whitespace, so any multi-word argument (e.g. a -p prompt) silently gets cut
+ * down to its first word. .cmd/.bat launchers (claude.cmd on Windows) require
+ * shell: true to spawn at all, so args must be pre-quoted for cmd.exe here.
+ * Quotes only when needed; doubles embedded double-quotes (cmd.exe's escaping
+ * rule), matching the common case — not a full CommandLineToArgvW-equivalent
+ * parser for every edge case (e.g. trailing backslashes before a quote).
+ */
+export function quoteForWindowsShell(arg: string): string {
+  if (arg === '') return '""';
+  if (!/[\s"^&|<>()]/.test(arg)) return arg;
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
 export function launchClaude(
   env: NodeJS.ProcessEnv,
   model: string | undefined,
@@ -55,7 +71,8 @@ export function launchClaude(
 ): Promise<number> {
   return new Promise((resolve) => {
     const claudePath = findClaudeBinary()!;
-    const args = buildClaudeArgs(model, extraArgs);
+    const rawArgs = buildClaudeArgs(model, extraArgs);
+    const args = isWindows ? rawArgs.map(quoteForWindowsShell) : rawArgs;
 
     const debugFileIdx = extraArgs.indexOf('--debug-file');
     const debugLogPath = debugFileIdx !== -1 && extraArgs[debugFileIdx + 1] ? extraArgs[debugFileIdx + 1] : undefined;

--- a/tests/launch.test.ts
+++ b/tests/launch.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'no
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { findBinaryOnPath } from '../src/binary-lookup.js';
-import { buildClaudeArgs, findClaudeBinary } from '../src/launch.js';
+import { buildClaudeArgs, findClaudeBinary, quoteForWindowsShell } from '../src/launch.js';
 import { buildGeminiChildEnv, prepareGeminiChildEnv } from '../src/gemini/launch.js';
 import { setAppPathOverride } from '../src/config.js';
 
@@ -37,6 +37,34 @@ describe('buildClaudeArgs', () => {
       '--print',
       'hello',
     ]);
+  });
+});
+
+describe('quoteForWindowsShell', () => {
+  // Regression: Node's child_process.spawn does not escape args when
+  // { shell: true } is used — required on Windows to spawn claude.cmd.
+  // cmd.exe re-tokenizes on whitespace, silently truncating a multi-word
+  // -p prompt to its first word before it ever reaches Claude Code.
+  it('leaves plain single-token args unquoted', () => {
+    expect(quoteForWindowsShell('--model')).toBe('--model');
+    expect(quoteForWindowsShell('claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+  });
+
+  it('quotes args containing spaces', () => {
+    expect(quoteForWindowsShell('hello world')).toBe('"hello world"');
+  });
+
+  it('quotes and escapes embedded double quotes', () => {
+    expect(quoteForWindowsShell('say "hi" now')).toBe('"say ""hi"" now"');
+  });
+
+  it('quotes args containing cmd.exe metacharacters even without spaces', () => {
+    expect(quoteForWindowsShell('a&b')).toBe('"a&b"');
+    expect(quoteForWindowsShell('a|b')).toBe('"a|b"');
+  });
+
+  it('represents an empty string as an explicit empty quoted arg', () => {
+    expect(quoteForWindowsShell('')).toBe('""');
   });
 });
 


### PR DESCRIPTION
## Problem

`launchClaude` spawns Claude Code with `{ shell: true }` on Windows — required because `claude.cmd` can only be spawned through a shell. Node's `child_process.spawn` does not escape arguments when `shell: true` is used (documented Node behavior). cmd.exe re-tokenizes the command line on whitespace, so any multi-word argument — most notably a `-p`/`--print` prompt — is silently truncated to its first word before it ever reaches Claude Code. E.g. `relay-ai claude -p "What is 7 times 8?"` reaches Claude Code as just `What`.

This breaks the non-interactive/agent-platform use case (`-p`, `exec --json`) documented as a first-class pattern in the skill reference — the launch itself succeeds, so the failure is silent rather than an obvious crash.

## Change

- Add `quoteForWindowsShell(arg)` in `src/launch.ts`: quotes an argument when it contains whitespace or a cmd.exe metacharacter (`&|<>()^`), doubling any embedded double-quotes per cmd.exe's escaping rule.
- Apply it to `launchClaude`'s spawn args, only on `win32` (non-Windows platforms use the args array unmodified, as before).

Covers the common case (spaces, embedded quotes, metacharacters) rather than a full `CommandLineToArgvW`-equivalent parser for every edge case (e.g. trailing backslashes immediately before a quote).

## Tests

Adds a `describe('quoteForWindowsShell', ...)` block to `tests/launch.test.ts`: plain args pass through unquoted, spaces get quoted, embedded quotes get doubled, metacharacters get quoted even without spaces, empty string becomes `""`.

## Limitations / notes

No behavior change on macOS/Linux. Windows-only fix for a Windows-only bug.