### PR TITLE
fix(cli): claude-app/codex-app --help falls through to TTY check

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsup && mkdir -p dist/ui/public && cp -r src/ui/public/. dist/ui/public/",
+    "build": "tsup && node -e \"require('fs').cpSync('src/ui/public','dist/ui/public',{recursive:true})\"",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,8 +37,8 @@ import { runProvidersCommand, providersHelpText } from './providers-command.js';
 import { runCodexCommand, codexHelpText } from './codex.js';
 import { runGeminiCommand, geminiHelpText } from './gemini.js';
 import { runAgyCommand, runAntigravityAppCommand, runAntigravityIdeCommand } from './antigravity.js';
-import { runCodexAppCommand } from './codex-app.js';
-import { runClaudeAppCommand } from './claude-app.js';
+import { runCodexAppCommand, codexAppHelpText } from './codex-app.js';
+import { runClaudeAppCommand, claudeAppHelpText } from './claude-app.js';
 import { prepareClaudeTraceLog, printTraceLog } from './trace-log.js';
 import { ANTIGRAVITY_BASE_URLS } from './oauth/antigravity-oauth.js';
 import { providersForTarget } from './target-compatibility.js';
@@ -1644,12 +1644,20 @@ Options:
       console.log(VERSION);
       return 0;
     }
+    if (parsed.showHelp) {
+      console.log(codexAppHelpText());
+      return 0;
+    }
     return runCodexAppCommand(parsed.claudeArgs, { vertex: parsed.vertex, launchProvider: parsed.launchProvider, launchModel: parsed.launchModel });
   }
 
   if (parsed.command === 'claude-app') {
     if (parsed.showVersion) {
       console.log(VERSION);
+      return 0;
+    }
+    if (parsed.showHelp) {
+      console.log(claudeAppHelpText());
       return 0;
     }
     return runClaudeAppCommand(parsed.claudeArgs, { launchProvider: parsed.launchProvider, launchModel: parsed.launchModel });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -469,6 +469,29 @@ describe('main routing', () => {
     await expect(main(['server', '--help'])).resolves.toBe(0);
     expect(log.mock.calls.flat().join('\n')).toContain('relay-ai server');
   });
+
+  // Regression: parseArgs sets showHelp for '--help' but does not include it in
+  // claudeArgs, so a dispatch branch that forgets to check parsed.showHelp
+  // silently drops the flag and falls through to the real command — for
+  // claude-app/codex-app that means hitting the "requires an interactive
+  // terminal" error instead of printing help.
+  it('prints claude-app help and returns 0', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(main(['claude-app', '--help'])).resolves.toBe(0);
+    expect(log.mock.calls.flat().join('\n')).toContain('relay-ai claude-app');
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('prints codex-app help and returns 0', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(main(['codex-app', '--help'])).resolves.toBe(0);
+    expect(log.mock.calls.flat().join('\n')).toContain('relay-ai codex-app');
+    expect(error).not.toHaveBeenCalled();
+  });
 });
 
 describe('parseArgs — antigravity commands', () => {


### PR DESCRIPTION
## Summary
- `parseArgs` sets `showHelp` for `--help` but doesn't include it in `claudeArgs`. The `claude-app` and `codex-app` dispatch branches in `cli.ts` were the only two of six help-capable commands that never checked `parsed.showHelp` before invoking the command, so `--help`/`-h` was silently dropped and execution fell through to `runClaudeAppCommand`/`runCodexAppCommand`, which then failed with "requires an interactive terminal" instead of printing help.
- The build script's `mkdir -p dist/ui/public && cp -r src/ui/public/. dist/ui/public/` postbuild step isn't native `cmd.exe` syntax on Windows. It fails silently (npm doesn't propagate the exit code as a build failure) and was deleting `dist/ui/public` on every Windows build without ever repopulating it. Replaced with `node -e "require('fs').cpSync(...)"`, which is cross-platform and verified to produce byte-identical output to the old `cp -r`.

## Test plan
- [x] `relay-ai claude-app --help` and `relay-ai codex-app --help` now print help text and exit 0 (previously errored with "requires an interactive terminal")
- [x] Added regression tests in `tests/cli.test.ts` covering both commands via `main()`
- [x] Full `vitest run` on Windows: no new failures (pre-existing baseline of 12 failures across 7 files, all POSIX-permission/process-detection tests unrelated to this change)
- [x] `npm run build` on Windows: exits cleanly, `dist/ui/public` content verified identical to `src/ui/public` via `diff -rq`