### PR TITLE
fix(env): strip parent Claude Code session identity vars from child launches

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,6 +52,20 @@ export const CONFLICTING_ENV_VARS = [
 
 export type ConflictingEnvVar = (typeof CONFLICTING_ENV_VARS)[number];
 
+// When relay-ai launches Claude Code from inside an existing Claude Code
+// session (its own terminal, a Code tab, an agent's shell), these identity
+// vars leak into the spawned child via process.env inheritance. The new
+// process then misidentifies itself as a nested child of the outer session
+// (e.g. CLAUDE_CODE_CHILD_SESSION disables transcript saving) even though
+// it's meant to be a fresh top-level launch. Strip before spawning.
+export const PARENT_SESSION_ENV_VARS = [
+  'CLAUDE_CODE_CHILD_SESSION',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_CODE_HOST_SESSION_ID',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_PID',
+] as const;
+
 // Optional enrichment from OpenCode CLI (~/.cache/opencode/models.json) — not a runtime dependency.
 export const OPENCODE_CACHE_PATH = join(homedir(), '.cache', 'opencode', 'models.json');
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,6 +59,7 @@ export type ConflictingEnvVar = (typeof CONFLICTING_ENV_VARS)[number];
 // (e.g. CLAUDE_CODE_CHILD_SESSION disables transcript saving) even though
 // it's meant to be a fresh top-level launch. Strip before spawning.
 export const PARENT_SESSION_ENV_VARS = [
+  'CLAUDECODE',
   'CLAUDE_CODE_CHILD_SESSION',
   'CLAUDE_CODE_SESSION_ID',
   'CLAUDE_CODE_HOST_SESSION_ID',

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,5 @@
 // src/env.ts
-import { CONFLICTING_ENV_VARS } from './constants.js';
+import { CONFLICTING_ENV_VARS, PARENT_SESSION_ENV_VARS } from './constants.js';
 import { claudeCodeClientModelId, stripOneMContextSuffix } from './context-model-id.js';
 import { resolveContextWindow } from './context-window.js';
 import { oauthCredentialToKeychainJson } from './registry/opencode-auth.js';
@@ -51,6 +51,9 @@ export function buildChildEnv(
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const name of CONFLICTING_ENV_VARS) {
+    delete env[name];
+  }
+  for (const name of PARENT_SESSION_ENV_VARS) {
     delete env[name];
   }
   env['ANTHROPIC_BASE_URL'] = proxyPort

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -11,7 +11,7 @@ import {
   resolveProviderCredential,
   GLOBAL_OPENCODE_KEYRING_ACCOUNT,
 } from '../src/env.js';
-import { BACKENDS, CONFLICTING_ENV_VARS } from '../src/constants.js';
+import { BACKENDS, CONFLICTING_ENV_VARS, PARENT_SESSION_ENV_VARS } from '../src/constants.js';
 
 // Snapshot of all conflicting vars before any test so we can restore them
 const originalConflictingValues: Record<string, string | undefined> = {};
@@ -201,6 +201,28 @@ describe('buildChildEnv', () => {
     buildChildEnv(BACKENDS.zen.baseUrl, 'claude-sonnet-4-6', 'my-key');
     expect(process.env['CLAUDE_CODE_USE_VERTEX']).toBe('1');
     expect(process.env['ANTHROPIC_VERTEX_PROJECT_ID']).toBe('my-project');
+  });
+
+  // Regression: launching relay-ai from inside an existing Claude Code session
+  // (its own terminal, a Code tab, an agent's shell) leaked the outer session's
+  // identity vars into the spawned child via process.env inheritance. The new
+  // process then misidentified itself as a nested child of the outer session —
+  // CLAUDE_CODE_CHILD_SESSION specifically disables transcript saving — even
+  // though it's meant to be a fresh top-level launch.
+  it('strips parent Claude Code session identity vars from child env', () => {
+    for (const name of PARENT_SESSION_ENV_VARS) {
+      process.env[name] = 'inherited-from-parent';
+    }
+    try {
+      const env = buildChildEnv(BACKENDS.zen.baseUrl, 'claude-sonnet-4-6', 'my-key');
+      for (const name of PARENT_SESSION_ENV_VARS) {
+        expect(env[name]).toBeUndefined();
+      }
+    } finally {
+      for (const name of PARENT_SESSION_ENV_VARS) {
+        delete process.env[name];
+      }
+    }
   });
 
   it('preserves non-conflicting env vars like PATH and HOME', () => {

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -225,6 +225,18 @@ describe('buildChildEnv', () => {
     }
   });
 
+  it('strips the Claude Code nested-session guard from child env', () => {
+    const original = process.env['CLAUDECODE'];
+    process.env['CLAUDECODE'] = '1';
+    try {
+      const env = buildChildEnv(BACKENDS.zen.baseUrl, 'claude-sonnet-4-6', 'my-key');
+      expect(env['CLAUDECODE']).toBeUndefined();
+    } finally {
+      if (original === undefined) delete process.env['CLAUDECODE'];
+      else process.env['CLAUDECODE'] = original;
+    }
+  });
+
   it('preserves non-conflicting env vars like PATH and HOME', () => {
     const env = buildChildEnv(BACKENDS.zen.baseUrl, 'claude-sonnet-4-6', 'my-key');
     expect(env['PATH']).toBe(process.env['PATH']);


### PR DESCRIPTION
## Summary
- `buildChildEnv` builds the spawned `claude` process's environment as `{...process.env}` minus a fixed allowlist of cloud-provider vars (`CONFLICTING_ENV_VARS` — Vertex/Bedrock/Foundry/stale Anthropic config). It never stripped Claude Code's own session-identity markers: `CLAUDE_CODE_CHILD_SESSION`, `CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_HOST_SESSION_ID`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_PID`.
- When `relay-ai claude` is launched from inside an existing Claude Code session (its own terminal, a Code tab, an agent's shell), those markers leak into the freshly-spawned child through ordinary environment inheritance. The new process then misidentifies itself as a nested child of the outer session — `CLAUDE_CODE_CHILD_SESSION` specifically disables transcript saving for the new session, even though it's meant to be a fresh top-level launch.
- Added a dedicated `PARENT_SESSION_ENV_VARS` constant (kept separate from `CONFLICTING_ENV_VARS`, which is about provider-auth conflicts, not session identity) and strip it in `buildChildEnv` alongside the existing conflict-var cleanup.

## Test plan
- [x] Added a regression test asserting `buildChildEnv` strips all `PARENT_SESSION_ENV_VARS` when present in `process.env`, while leaving unrelated vars untouched
- [x] Full `vitest run`: no new failures (pre-existing baseline of 3–4 failures across process-detection/billing-header tests, unrelated to `env.ts`/`constants.ts`)
- [x] `npm run typecheck` and `npm run build` both pass