### PR TITLE
fix(claude-app): don't clobber a live session's config on cleanup/--restore

### DIFF
--- a/src/claude-app.ts
+++ b/src/claude-app.ts
@@ -100,9 +100,9 @@ export async function runClaudeAppCommand(args: string[], boot?: { launchProvide
   }
 
   if (args.includes('--restore')) {
-    recoverSession();
-    console.log('Restored Claude Desktop relay-ai config.');
-    return 0;
+    const result = recoverSession();
+    console.log(result.message);
+    return result.liveSession ? 1 : 0;
   }
 
   const trace = args.includes('--trace');

--- a/src/claude-desktop/app-session.ts
+++ b/src/claude-desktop/app-session.ts
@@ -77,8 +77,30 @@ export function isConcurrentLiveSession(): boolean {
   return isProcessAlive(lock.pid);
 }
 
-export function recoverSession(): void {
+// True when the on-disk lock belongs to a different, still-running relay-ai
+// process. cleanupSession/recoverSession must not touch shared state
+// (_meta.json, the lock file) in that case — a second claude-app launch may
+// have taken over the lock, and restoring/deleting it here would corrupt
+// that live session instead of our own.
+function lockHeldByAnotherLiveProcess(lock: ClaudeSessionLock | null): boolean {
+  return lock !== null && lock.pid !== process.pid && isProcessAlive(lock.pid);
+}
+
+export type RecoverSessionResult = {
+  recovered: boolean;
+  liveSession?: boolean;
+  message: string;
+};
+
+export function recoverSession(): RecoverSessionResult {
   const lock = readSessionLock();
+  if (lockHeldByAnotherLiveProcess(lock)) {
+    return {
+      recovered: false,
+      liveSession: true,
+      message: `Another relay-ai claude-app session is running (pid ${lock!.pid}). Ctrl+C it first, then run --restore.`,
+    };
+  }
   if (lock) {
     restoreMetaJson();
     removeRelayAiConfig(lock.uuid);
@@ -87,6 +109,7 @@ export function recoverSession(): void {
     // Just in case there is no lock but the backup exists
     restoreMetaJson();
   }
+  return { recovered: true, message: 'Restored Claude Desktop relay-ai config.' };
 }
 
 export function waitForShutdown(): Promise<'sigint' | 'sigterm'> {
@@ -109,9 +132,12 @@ export function waitForShutdown(): Promise<'sigint' | 'sigterm'> {
 }
 
 export function cleanupSession(uuid: string): void {
-  restoreMetaJson();
+  const lock = readSessionLock();
+  if (!lockHeldByAnotherLiveProcess(lock)) {
+    restoreMetaJson();
+    try { rmSync(getSessionLockPath(), { force: true }); } catch { /* ignore */ }
+  }
   removeRelayAiConfig(uuid);
-  try { rmSync(getSessionLockPath(), { force: true }); } catch { /* ignore */ }
 }
 
 export function setupExitCleanup(uuid: string): void {

--- a/tests/claude-app-session.test.ts
+++ b/tests/claude-app-session.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  cleanupSession,
+  getSessionLockPath,
+  readSessionLock,
+  recoverSession,
+  writeSessionLock,
+} from '../src/claude-desktop/app-session.js';
+import { getConfigLibraryPath, getMetaJsonPath } from '../src/claude-desktop/app-config.js';
+
+// Two concurrent `claude-app` launches share one Claude-3p home: one
+// _meta.json, one .relay-ai.lock, one .bak. If a second launch takes over
+// the lock, the first process's eventual cleanup/--restore must leave that
+// shared state alone instead of clobbering the still-live session.
+describe('claude-app session ownership', () => {
+  let home: string;
+  let prevLocalAppData: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'relay-claude-app-session-'));
+    prevLocalAppData = process.env.LOCALAPPDATA;
+    prevHome = process.env.HOME;
+    process.env.LOCALAPPDATA = home;
+    process.env.HOME = home;
+    mkdirSync(getConfigLibraryPath(), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    if (prevLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+    else process.env.LOCALAPPDATA = prevLocalAppData;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+  });
+
+  it('allows the owning process to clean up its own session', () => {
+    writeFileSync(getMetaJsonPath(), JSON.stringify({ appliedId: 'our-uuid', entries: [{ id: 'our-uuid', name: 'Relay AI Gateway' }] }));
+    writeFileSync(`${getMetaJsonPath()}.bak`, JSON.stringify({ appliedId: '', entries: [] }));
+    writeFileSync(join(getConfigLibraryPath(), 'our-uuid.json'), '{}');
+    writeSessionLock({ pid: process.pid, startedAt: new Date().toISOString(), uuid: 'our-uuid', proxyPort: 11111 });
+
+    cleanupSession('our-uuid');
+
+    expect(JSON.parse(readFileSync(getMetaJsonPath(), 'utf8'))).toEqual({ appliedId: '', entries: [] });
+    expect(existsSync(getSessionLockPath())).toBe(false);
+    expect(existsSync(join(getConfigLibraryPath(), 'our-uuid.json'))).toBe(false);
+  });
+
+  it('does not restore shared state when another live process holds the lock', () => {
+    // Our own (now-orphaned) config from an earlier launch.
+    writeFileSync(`${getMetaJsonPath()}.bak`, JSON.stringify({ appliedId: '', entries: [] }));
+    writeFileSync(join(getConfigLibraryPath(), 'our-uuid.json'), '{}');
+
+    // A second, still-running relay-ai process has since taken over: it
+    // wrote its own config/lock and its appliedId is what Desktop is using
+    // right now. process.ppid stands in for "a genuinely different live pid".
+    const otherLiveState = { appliedId: 'other-uuid', entries: [{ id: 'other-uuid', name: 'Relay AI Gateway' }] };
+    writeFileSync(getMetaJsonPath(), JSON.stringify(otherLiveState));
+    writeFileSync(join(getConfigLibraryPath(), 'other-uuid.json'), '{}');
+    writeSessionLock({ pid: process.ppid, startedAt: new Date().toISOString(), uuid: 'other-uuid', proxyPort: 22222 });
+
+    cleanupSession('our-uuid');
+
+    // Shared state belongs to the other live session — must be untouched.
+    expect(JSON.parse(readFileSync(getMetaJsonPath(), 'utf8'))).toEqual(otherLiveState);
+    expect(readSessionLock()).toMatchObject({ pid: process.ppid, uuid: 'other-uuid' });
+    expect(existsSync(join(getConfigLibraryPath(), 'other-uuid.json'))).toBe(true);
+    // Our own orphaned config is still safe to remove.
+    expect(existsSync(join(getConfigLibraryPath(), 'our-uuid.json'))).toBe(false);
+  });
+
+  it('--restore refuses to clobber another live session', () => {
+    const otherLiveState = { appliedId: 'other-uuid', entries: [{ id: 'other-uuid', name: 'Relay AI Gateway' }] };
+    writeFileSync(getMetaJsonPath(), JSON.stringify(otherLiveState));
+    writeFileSync(`${getMetaJsonPath()}.bak`, JSON.stringify({ appliedId: '', entries: [] }));
+    writeSessionLock({ pid: process.ppid, startedAt: new Date().toISOString(), uuid: 'other-uuid', proxyPort: 22222 });
+
+    const result = recoverSession();
+
+    expect(result).toMatchObject({ recovered: false, liveSession: true });
+    expect(result.message).toContain(String(process.ppid));
+    expect(JSON.parse(readFileSync(getMetaJsonPath(), 'utf8'))).toEqual(otherLiveState);
+    expect(readSessionLock()).toMatchObject({ pid: process.ppid, uuid: 'other-uuid' });
+  });
+});

--- a/tests/claude-app.test.ts
+++ b/tests/claude-app.test.ts
@@ -20,7 +20,7 @@ vi.mock('@clack/prompts', () => ({
 }));
 vi.mock('../src/claude-desktop/app-session.js', () => ({
   readSessionLock: vi.fn(),
-  recoverSession: vi.fn(),
+  recoverSession: vi.fn(() => ({ recovered: true, message: 'Restored Claude Desktop relay-ai config.' })),
   hasStaleSession: vi.fn(() => false),
   writeSessionLock: vi.fn(),
   setupExitCleanup: vi.fn(),
@@ -152,6 +152,19 @@ describe('runClaudeAppCommand', () => {
     expect(code).toBe(0);
     expect(recoverSession).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Restored'));
+  });
+
+  it('exits 1 and leaves config alone when --restore finds another live session', async () => {
+    vi.mocked(recoverSession).mockReturnValueOnce({
+      recovered: false,
+      liveSession: true,
+      message: 'Another relay-ai claude-app session is running (pid 4242). Ctrl+C it first, then run --restore.',
+    });
+
+    const code = await runClaudeAppCommand(['--restore']);
+
+    expect(code).toBe(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Another relay-ai claude-app session is running'));
   });
 
   it('preserves OAuth and model metadata for direct single-model launches', async () => {


### PR DESCRIPTION
## Summary
- `cleanupSession()` and `recoverSession()` in `src/claude-desktop/app-session.ts` unconditionally restored `_meta.json` from `.bak` and deleted `.relay-ai.lock`, with no check that the lock still belonged to the exiting process.
- Reproduced live on my own machine: two concurrent `claude-app` launches ended up on the same Claude-3p home (one on port 57887, one on port 62125). The second launch's `_meta.json`/lock write was never guarded against by the first process's later cleanup — closing the *older* session's terminal would have silently reverted the *currently active* session's gateway config and deleted its lock out from under it, breaking a running Desktop connection with no visible error.
- `codex-app` already solved this exact problem — `restoreCodexAppOverlay()` checks `lock.pid !== process.pid && isConcurrentSession(lock)` before touching shared state and returns a `liveSession` result instead of clobbering. This PR ports the same pattern to `claude-app`.

## Changes
- `recoverSession()` now returns `{ recovered, liveSession?, message }` instead of `void`, and refuses to restore `_meta.json`/delete the lock when a different, still-alive process currently owns it — mirroring `restoreCodexAppOverlay()`.
- `cleanupSession(uuid)` gets the same ownership check. It still removes its own orphaned config file (`configLibrary/<uuid>.json`) in the "taken over" case, since that file is keyed by its own uuid and safe to remove regardless of who holds the lock.
- `claude-app.ts`'s `--restore` handler now prints `result.message` and exits `1` when `liveSession` is true, matching `codex-app`'s `--restore` exit-code convention.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] New `tests/claude-app-session.test.ts` (3 tests) exercises the real (non-mocked) session module against a temp Claude-3p home: owning-process cleanup still works; cleanup/`--restore` both leave shared state untouched when another live pid holds the lock (using `process.ppid` as a genuinely different, guaranteed-alive pid, same technique as `codex-session.test.ts`).
- [x] Updated `tests/claude-app.test.ts` mock for the new `recoverSession()` return shape; added a case for the blocked-restore → exit 1 path.
- [x] Full suite: 1174 passed, 3 pre-existing environment-only failures unrelated to this change (billing-header `cc_entrypoint` detection + a proxy fallback test, same failures present on `main` when run inside a relay-ai-wrapped terminal), 8 skipped.
- [x] `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)