### PR TITLE
fix Codex mixed mode on Windows

### DIFF
--- a/src/codex-app.ts
+++ b/src/codex-app.ts
@@ -1,7 +1,6 @@
 // codex-app.ts — relay-ai codex-app / chatgpt: launch the ChatGPT desktop app (Codex mode) with registry providers
 import pc from 'picocolors';
 import * as p from '@clack/prompts';
-import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { fetchProviderCatalog, providersForPicker, resolveLocalProviderApiKey } from './provider-catalog.js';
 import { loadPreferences, savePreferences } from './config.js';
@@ -12,6 +11,7 @@ import type { CodexProxyHandle, CodexProxyRoute } from './codex-proxy.js';
 import { getCodexProxyDebugLogPath, printTraceLog } from './trace-log.js';
 import { buildAppCatalogFile, formatCodexModelLabel, serializeCatalog } from './codex/catalog.js';
 import { captureNativeCodexCatalog } from './codex/native-catalog.js';
+import { runCodexCommandSync } from './codex/process.js';
 import { buildCodexMixedLaunchPlan, prepareCodexMixedRelayRoutes } from './codex/mixed-launch.js';
 import { supportsMultiAgentV2 } from './codex/multi-agent.js';
 import { mixedProxyBaseUrl } from './codex/routing.js';
@@ -511,7 +511,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     try {
       const embeddedBinary = findEmbeddedCodexBinary();
       if (!embeddedBinary) throw new Error('Embedded ChatGPT/Codex runtime was not found; mixed Desktop mode is unavailable on this installation');
-      const version = execFileSync(embeddedBinary, ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+      const version = runCodexCommandSync(embeddedBinary, ['--version']).stdout.trim();
       const mixedModels = await resolveCodexMixedModels({
         activeProvider,
         selectedModel,

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -1,7 +1,6 @@
 // codex.ts — relay-ai codex: launch OpenAI Codex CLI with registry providers
 import pc from 'picocolors';
 import * as p from '@clack/prompts';
-import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { fetchProviderCatalog, providersForPicker, resolveLocalProviderApiKey } from './provider-catalog.js';
 import { loadPreferences, recordLaunchSelection } from './config.js';
@@ -58,6 +57,7 @@ import {
   resolveCodexFavorites,
 } from './codex/favorites-launch.js';
 import { captureNativeCodexCatalog } from './codex/native-catalog.js';
+import { runCodexCommandSync } from './codex/process.js';
 import { buildCodexMixedLaunchPlan, prepareCodexMixedRelayRoutes } from './codex/mixed-launch.js';
 import { supportsMultiAgentV2 } from './codex/multi-agent.js';
 import { mixedProxyBaseUrl } from './codex/routing.js';
@@ -556,7 +556,7 @@ export async function runCodexCommand(
   let mixedPlan: ReturnType<typeof buildCodexMixedLaunchPlan> | null = null;
   if (mixedMode) {
     try {
-      const version = execFileSync(codexPath, ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+      const version = runCodexCommandSync(codexPath, ['--version']).stdout.trim();
       const mixedModels = await resolveCodexMixedModels({
         activeProvider,
         selectedModel,

--- a/src/codex/launch.ts
+++ b/src/codex/launch.ts
@@ -1,5 +1,6 @@
 // Spawn Codex CLI with relay-ai-launch profile.
-import { execFileSync, execSync, spawn } from 'node:child_process';
+import { execSync } from 'node:child_process';
+import spawn from 'cross-spawn';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -8,6 +9,7 @@ import { codexProviderEnvKey } from './routing.js';
 import type { CodexRoute } from './routing.js';
 import { PROXY_PLACEHOLDER_KEY } from '../codex-proxy.js';
 import { getAppPathOverride } from '../config.js';
+import { runCodexCommandSync } from './process.js';
 
 const isWindows = process.platform === 'win32';
 
@@ -82,12 +84,7 @@ export function selectCodexBinary(
 
 function canRunCodexBinary(path: string): boolean {
   try {
-    execFileSync(path, ['--version'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 5000,
-      shell: isWindows,
-    });
+    runCodexCommandSync(path, ['--version'], { timeout: 5000 });
     return true;
   } catch {
     return false;
@@ -142,7 +139,6 @@ export function launchCodex(
     const child = spawn(codexPath, args, {
       stdio: 'inherit',
       env,
-      shell: isWindows,
     });
 
     const forward = (signal: NodeJS.Signals): void => {

--- a/src/codex/multi-agent.ts
+++ b/src/codex/multi-agent.ts
@@ -1,7 +1,7 @@
-import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { runCodexCommandSync } from './process.js';
 
 /** The Codex Router-compatible feature shape that exposes model overrides. */
 export const CODEX_MULTI_AGENT_V2 = Object.freeze({
@@ -30,12 +30,7 @@ function probeText(value: unknown): string {
  */
 export function supportsMultiAgentV2(
   binaryPath: string,
-  run: ProbeRunner = (path, args, env) => execFileSync(path, args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: 10_000,
-    env,
-  }),
+  run: ProbeRunner = (path, args, env) => runCodexCommandSync(path, args, { timeout: 10_000, env }),
 ): boolean {
   const probeHome = mkdtempSync(join(tmpdir(), 'relay-codex-v2-probe-'));
   try {

--- a/src/codex/native-catalog.ts
+++ b/src/codex/native-catalog.ts
@@ -1,8 +1,5 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import type { CodexCatalogFile, CodexCatalogModel } from './catalog.js';
-
-const execFileAsync = promisify(execFile);
+import { runCodexCommand } from './process.js';
 
 export interface NativeCodexCatalogSnapshot {
   schemaVersion: 1;
@@ -45,7 +42,7 @@ export async function captureNativeCodexCatalog(
   options: CaptureNativeCodexCatalogOptions,
 ): Promise<NativeCodexCatalogSnapshot> {
   const run = options.run ?? (async (args: string[]) => {
-    const result = await execFileAsync(options.binaryPath, args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+    const result = await runCodexCommand(options.binaryPath, args, { maxBuffer: 16 * 1024 * 1024 });
     return result.stdout;
   });
   const stdout = await run(options.bundled ? ['debug', 'models', '--bundled'] : ['debug', 'models']);

--- a/src/codex/process.ts
+++ b/src/codex/process.ts
@@ -1,0 +1,109 @@
+import spawn from 'cross-spawn';
+
+export interface CodexCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface CodexCommandOptions {
+  env?: NodeJS.ProcessEnv;
+  timeout?: number;
+  maxBuffer?: number;
+}
+
+function commandError(
+  binaryPath: string,
+  args: string[],
+  stdout: string,
+  stderr: string,
+  detail: string,
+): Error {
+  const error = new Error(`Command failed: ${binaryPath} ${args.join(' ')} (${detail})`);
+  return Object.assign(error, { stdout, stderr });
+}
+
+/**
+ * Run an npm-installed Codex command without relying on Node's raw child-process
+ * handling. cross-spawn resolves Windows .cmd shims while preserving argv.
+ */
+export function runCodexCommandSync(
+  binaryPath: string,
+  args: string[],
+  options: CodexCommandOptions = {},
+): CodexCommandResult {
+  const result = spawn.sync(binaryPath, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: options.env,
+    timeout: options.timeout,
+    maxBuffer: options.maxBuffer,
+  });
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  if (result.error) {
+    throw Object.assign(result.error, { stdout, stderr });
+  }
+  if (result.status !== 0) {
+    throw commandError(binaryPath, args, stdout, stderr, `exit ${result.status ?? result.signal ?? 'unknown'}`);
+  }
+  return { stdout, stderr };
+}
+
+export function runCodexCommand(
+  binaryPath: string,
+  args: string[],
+  options: CodexCommandOptions = {},
+): Promise<CodexCommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binaryPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: options.env,
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let outputBytes = 0;
+    let settled = false;
+
+    const finishError = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      reject(Object.assign(error, {
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      }));
+    };
+    const collect = (target: Buffer[], chunk: Buffer): void => {
+      target.push(chunk);
+      outputBytes += chunk.length;
+      if (options.maxBuffer !== undefined && outputBytes > options.maxBuffer) {
+        child.kill();
+        finishError(commandError(binaryPath, args, '', '', `output exceeded ${options.maxBuffer} bytes`));
+      }
+    };
+
+    child.stdout?.on('data', (chunk: Buffer) => collect(stdoutChunks, chunk));
+    child.stderr?.on('data', (chunk: Buffer) => collect(stderrChunks, chunk));
+    child.on('error', finishError);
+
+    let timer: NodeJS.Timeout | undefined;
+    if (options.timeout !== undefined) {
+      timer = setTimeout(() => {
+        child.kill();
+        finishError(commandError(binaryPath, args, '', '', `timed out after ${options.timeout}ms`));
+      }, options.timeout);
+    }
+
+    child.on('close', (code, signal) => {
+      if (timer) clearTimeout(timer);
+      if (settled) return;
+      const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf8');
+      if (code !== 0) {
+        finishError(commandError(binaryPath, args, stdout, stderr, `exit ${code ?? signal ?? 'unknown'}`));
+        return;
+      }
+      settled = true;
+      resolve({ stdout, stderr });
+    });
+  });
+}

--- a/tests/codex-process.test.ts
+++ b/tests/codex-process.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runCodexCommand, runCodexCommandSync } from '../src/codex/process.js';
+
+const windowsOnly = process.platform === 'win32' ? describe : describe.skip;
+const cleanup: string[] = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+function windowsArgEchoShim(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'relay codex cmd '));
+  cleanup.push(dir);
+  writeFileSync(join(dir, 'echo-args.cjs'), 'process.stdout.write(JSON.stringify(process.argv.slice(2)));\n');
+  const shim = join(dir, 'codex test.cmd');
+  writeFileSync(shim, '@echo off\r\nnode "%~dp0echo-args.cjs" %*\r\n');
+  return shim;
+}
+
+const edgeCaseArgs = [
+  'plain',
+  'two words',
+  'say "hello"',
+  '%PATH%',
+  'a&b',
+  '',
+  'Unicode-☃',
+  'C:\\trailing\\',
+];
+
+windowsOnly('Codex Windows command shims', () => {
+  it('runs a .cmd shim synchronously without changing its arguments', () => {
+    const result = runCodexCommandSync(windowsArgEchoShim(), edgeCaseArgs);
+    expect(JSON.parse(result.stdout)).toEqual(edgeCaseArgs);
+  });
+
+  it('runs a .cmd shim asynchronously without changing its arguments', async () => {
+    const result = await runCodexCommand(windowsArgEchoShim(), edgeCaseArgs);
+    expect(JSON.parse(result.stdout)).toEqual(edgeCaseArgs);
+  });
+});


### PR DESCRIPTION
## What changed

- use `cross-spawn` for Codex CLI discovery, mixed-mode probes, native-catalog capture, and launch
- remove the Windows `shell: true` launch path
- add real Windows `.cmd` integration coverage for synchronous and asynchronous probes

## Root cause

Mixed mode found the npm-installed `codex.cmd` shim, then called it with Node's raw `execFileSync`/`execFile`. On Windows that fails with `spawnSync ... codex.cmd EINVAL` before Relay can capture the native model catalog. Relay's existing `cross-spawn` dependency already solves `.cmd` resolution and argument escaping for other launchers.

## User impact

`relay-ai codex --with-native` can now inspect and launch an npm-installed Codex CLI on Windows, exposing native Codex models alongside Relay routes.

## Validation

- `npm run typecheck`
- `npx vitest run tests/codex-process.test.ts tests/codex-native-catalog.test.ts tests/codex-multi-agent.test.ts` (8 passed)
- `npm run build`
- real Windows config probe: `node dist/cli.js codex --with-native --config --trace` captured 9 native Codex models and prepared 3 Relay routes
- full suite: 1,633 passed; 6 unrelated Windows failures reproduce unchanged on `main` in Linux-path, publish-workflow shim, and proxy-timeout tests

## Compatibility and security

The shared runner uses `cross-spawn` without `shell: true`, preserving argv and avoiding hand-written `cmd.exe` escaping. The Windows integration test covers spaces, quotes, percent variables, metacharacters, empty strings, Unicode, and trailing backslashes. Non-Windows execution uses the same cross-platform runner.