### PR TITLE
Fix Cloud Code schema translation for current Gemini models

### DIFF
--- a/src/antigravity/anthropic-to-cloudcode.ts
+++ b/src/antigravity/anthropic-to-cloudcode.ts
@@ -2,7 +2,6 @@
 // into the Cloud Code Assist envelope format for cloudcode-pa.googleapis.com.
 
 import { randomUUID } from 'node:crypto';
-import { normalizeJsonSchema } from './request-adapter.js';
 import { splitToolUseId } from '../proxy-shared.js';
 
 type JsonRecord = Record<string, unknown>;
@@ -18,12 +17,11 @@ const DEFAULT_SAFETY_SETTINGS = [
 
 const ANTIGRAVITY_USER_AGENT = 'vscode/1.X.X (Antigravity/4.2.0)';
 const MIN_ANTIGRAVITY_OUTPUT_TOKENS = 1024;
-const DISABLE_CLOUD_CODE_THINKING = { thinkingBudget: 0, includeThoughts: false };
 
 // Draft-meta keywords that Cloud Code rejects — strip them from tool schemas.
 const STRIP_KEYS = new Set([
   '$schema', '$defs', 'definitions', '$ref', '$comment',
-  'additionalProperties', 'propertyNames', 'patternProperties', 'title',
+  'additionalProperties', 'propertyNames', 'patternProperties', 'prefixItems', 'title',
   'exclusiveMinimum', 'exclusiveMaximum', 'minimum', 'maximum',
   'multipleOf', 'minLength', 'maxLength', 'pattern', 'format',
   'minItems', 'maxItems', 'uniqueItems', 'contains', 'minContains', 'maxContains',
@@ -32,13 +30,121 @@ const STRIP_KEYS = new Set([
   'const', 'default', 'examples', 'readOnly', 'writeOnly', 'deprecated',
 ]);
 
-function stripDraftMeta(obj: unknown): unknown {
+const CLOUD_CODE_SCHEMA_TYPES = new Map([
+  ['array', 'ARRAY'],
+  ['boolean', 'BOOLEAN'],
+  ['integer', 'INTEGER'],
+  ['null', 'NULL'],
+  ['number', 'NUMBER'],
+  ['object', 'OBJECT'],
+  ['string', 'STRING'],
+]);
+
+function normalizeCloudCodeSchemaType(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return CLOUD_CODE_SCHEMA_TYPES.get(value.toLowerCase()) ?? value;
+  }
+  return value;
+}
+
+function isNullSchema(obj: unknown): boolean {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+  const type = (obj as JsonRecord).type;
+  return type === 'null' || type === 'NULL'
+    || (Array.isArray(type) && type.every(value => value === 'null' || value === 'NULL'));
+}
+
+function resolveLocalSchemaRef(ref: string, root: JsonRecord): unknown {
+  if (!ref.startsWith('#/$defs/')) return undefined;
+  const name = ref.slice('#/$defs/'.length).replace(/~1/g, '/').replace(/~0/g, '~');
+  const defs = root.$defs;
+  if (!defs || typeof defs !== 'object' || Array.isArray(defs)) return undefined;
+  return (defs as JsonRecord)[name];
+}
+
+function stripDraftMeta(
+  obj: unknown,
+  root: JsonRecord | undefined = undefined,
+  resolvingRefs: ReadonlySet<string> = new Set(),
+): unknown {
   if (!obj || typeof obj !== 'object') return obj;
-  if (Array.isArray(obj)) return obj.map(stripDraftMeta);
+  if (Array.isArray(obj)) return obj.map(value => stripDraftMeta(value, root, resolvingRefs));
+  const source = obj as JsonRecord;
+  const schemaRoot = root ?? source;
+
+  if (typeof source.$ref === 'string') {
+    const resolved = resolveLocalSchemaRef(source.$ref, schemaRoot);
+    if (resolved !== undefined) {
+      if (resolvingRefs.has(source.$ref)) return { type: 'OBJECT' };
+      const nextRefs = new Set(resolvingRefs);
+      nextRefs.add(source.$ref);
+      const dereferenced = stripDraftMeta(resolved, schemaRoot, nextRefs);
+      if (dereferenced && typeof dereferenced === 'object' && !Array.isArray(dereferenced)) {
+        const siblings = { ...source };
+        delete siblings.$ref;
+        const sanitizedSiblings = stripDraftMeta(siblings, schemaRoot, resolvingRefs);
+        return {
+          ...(dereferenced as JsonRecord),
+          ...(sanitizedSiblings as JsonRecord),
+        };
+      }
+      return dereferenced;
+    }
+  }
+
   const out: JsonRecord = {};
-  for (const [k, v] of Object.entries(obj as JsonRecord)) {
+  for (const [k, v] of Object.entries(source)) {
     if (STRIP_KEYS.has(k) || k.startsWith('x-')) continue;
-    out[k] = stripDraftMeta(v);
+    if (k === 'properties' && v && typeof v === 'object' && !Array.isArray(v)) {
+      out.properties = Object.fromEntries(
+        Object.entries(v as JsonRecord).map(([name, schema]) => [
+          name,
+          stripDraftMeta(schema, schemaRoot, resolvingRefs),
+        ]),
+      );
+      continue;
+    }
+    if (k === 'type') {
+      const types = (Array.isArray(v) ? v : [v])
+        .map(normalizeCloudCodeSchemaType)
+        .filter((type): type is string => typeof type === 'string');
+      const concreteType = types.find(type => type !== 'NULL');
+      out.type = concreteType ?? 'STRING';
+      if (types.includes('NULL')) out.nullable = true;
+      continue;
+    }
+    if (k === 'enum' && Array.isArray(v)) {
+      out.enum = v.filter(value => value !== null && value !== undefined).map(String);
+      continue;
+    }
+    if (k === 'items' && Array.isArray(v)) {
+      out.items = stripDraftMeta(v[0] ?? {}, schemaRoot, resolvingRefs);
+      continue;
+    }
+    out[k] = stripDraftMeta(v, schemaRoot, resolvingRefs);
+  }
+
+  const union = Array.isArray(source.anyOf)
+    ? source.anyOf
+    : Array.isArray(source.oneOf)
+      ? source.oneOf
+      : undefined;
+  if (union) {
+    const nullable = union.some(isNullSchema);
+    const alternatives = union
+      .filter(branch => !isNullSchema(branch))
+      .map(branch => stripDraftMeta(branch, schemaRoot, resolvingRefs))
+      .filter((branch): branch is JsonRecord => Boolean(branch) && typeof branch === 'object' && !Array.isArray(branch));
+    if (alternatives.length === 1) Object.assign(out, alternatives[0], out);
+    else if (alternatives.length > 1) out.anyOf = alternatives;
+    if (nullable) out.nullable = true;
+  }
+  if (!out.type) {
+    if (out.properties && typeof out.properties === 'object' && !Array.isArray(out.properties)) {
+      out.type = 'OBJECT';
+    } else if (out.items && typeof out.items === 'object' && !Array.isArray(out.items)) {
+      out.type = 'ARRAY';
+    }
   }
   // Trim `required` to only list fields that survived in `properties`.
   if (Array.isArray(out.required) && out.properties && typeof out.properties === 'object') {
@@ -119,10 +225,15 @@ function translateTools(tools: unknown): JsonRecord[] | undefined {
   const decls: JsonRecord[] = [];
   for (const t of tools as JsonRecord[]) {
     if (typeof t.name !== 'string') continue;
+    const translated = stripDraftMeta(t.input_schema ?? { type: 'object', properties: {} });
+    const parameters = translated && typeof translated === 'object' && !Array.isArray(translated)
+      ? translated as JsonRecord
+      : { type: 'OBJECT', properties: {} };
+    if (!parameters.type) parameters.type = 'OBJECT';
     decls.push({
       name: t.name,
       description: typeof t.description === 'string' ? t.description : '',
-      parameters: stripDraftMeta(normalizeJsonSchema(t.input_schema ?? { type: 'object', properties: {} })),
+      parameters,
     });
   }
   return decls.length > 0
@@ -176,7 +287,6 @@ export function anthropicToCloudCode(
   }
   if (typeof body.temperature === 'number') generationConfig.temperature = body.temperature;
   if (typeof body.top_p === 'number') generationConfig.topP = body.top_p;
-  generationConfig.thinkingConfig = DISABLE_CLOUD_CODE_THINKING;
 
   const ccTools = translateTools(body.tools);
   const systemInstruction = extractSystem(body.system);

--- a/src/antigravity/anthropic-to-cloudcode.ts
+++ b/src/antigravity/anthropic-to-cloudcode.ts
@@ -28,6 +28,9 @@ const STRIP_KEYS = new Set([
   'minProperties', 'maxProperties', 'dependencies', 'dependentRequired', 'dependentSchemas',
   'allOf', 'anyOf', 'oneOf', 'not', 'if', 'then', 'else',
   'const', 'default', 'examples', 'readOnly', 'writeOnly', 'deprecated',
+  // Codex app tool schemas can include this internal annotation. It is not a
+  // JSON Schema keyword and Cloud Code's Schema protobuf rejects it.
+  'encrypted',
 ]);
 
 const CLOUD_CODE_SCHEMA_TYPES = new Map([

--- a/tests/antigravity-anthropic-to-cloudcode.test.ts
+++ b/tests/antigravity-anthropic-to-cloudcode.test.ts
@@ -3,6 +3,34 @@ import { anthropicToCloudCode } from '../src/antigravity/anthropic-to-cloudcode.
 import { collectCloudCodeToAnthropic } from '../src/antigravity/cloudcode-to-anthropic.js';
 
 describe('anthropicToCloudCode', () => {
+  it('preserves user and assistant perspective through the Google role mapping', () => {
+    const envelope = anthropicToCloudCode({
+      messages: [
+        { role: 'user', content: 'USER_MARKER' },
+        { role: 'assistant', content: 'ASSISTANT_REPLY' },
+        { role: 'user', content: 'USER_CORRECTION' },
+      ],
+    }, 'gemini-3-pro', 'project-id');
+
+    expect((envelope.request as any).contents).toEqual([
+      { role: 'user', parts: [{ text: 'USER_MARKER' }] },
+      { role: 'model', parts: [{ text: 'ASSISTANT_REPLY' }] },
+      { role: 'user', parts: [{ text: 'USER_CORRECTION' }] },
+    ]);
+  });
+
+  it('presents the request as the Antigravity Google client using Google One AI credit', () => {
+    const envelope = anthropicToCloudCode({
+      messages: [{ role: 'user', content: 'hello' }],
+    }, 'gemini-3-pro', 'project-id');
+
+    expect(envelope.userAgent).toBe('vscode/1.X.X (Antigravity/4.2.0)');
+    expect(envelope.requestType).toBe('agent');
+    expect(envelope.enabledCreditTypes).toEqual(['GOOGLE_ONE_AI']);
+    expect(envelope.project).toBe('project-id');
+    expect(envelope.model).toBe('gemini-3-pro');
+  });
+
   it('floors maxOutputTokens so Gemini hidden thoughts do not consume the full budget', () => {
     const envelope = anthropicToCloudCode({
       max_tokens: 64,

--- a/tests/antigravity-anthropic-to-cloudcode.test.ts
+++ b/tests/antigravity-anthropic-to-cloudcode.test.ts
@@ -99,6 +99,44 @@ describe('anthropicToCloudCode', () => {
     expect(JSON.stringify(parameters)).not.toContain('exclusiveMinimum');
   });
 
+  it('strips Codex encrypted annotations from nested tool properties', () => {
+    const envelope = anthropicToCloudCode({
+      max_tokens: 64,
+      messages: [{ role: 'user', content: 'use the tool' }],
+      tools: [{
+        name: 'codex_tool',
+        input_schema: {
+          type: 'object',
+          properties: {
+            authority: {
+              type: 'object',
+              encrypted: true,
+              properties: {
+                token: { type: 'string', encrypted: true },
+              },
+            },
+          },
+        },
+      }],
+    }, 'gemini-3.7-flash-high', 'project-id');
+
+    const request = envelope.request as any;
+    const parameters = request.tools[0].functionDeclarations[0].parameters;
+
+    expect(parameters).toEqual({
+      type: 'OBJECT',
+      properties: {
+        authority: {
+          type: 'OBJECT',
+          properties: {
+            token: { type: 'STRING' },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(parameters)).not.toContain('encrypted');
+  });
+
   it('normalizes JSON Schema constructs that Cloud Code Schema rejects', () => {
     const envelope = anthropicToCloudCode({
       max_tokens: 64,

--- a/tests/antigravity-anthropic-to-cloudcode.test.ts
+++ b/tests/antigravity-anthropic-to-cloudcode.test.ts
@@ -12,17 +12,14 @@ describe('anthropicToCloudCode', () => {
     expect((envelope.request as any).generationConfig.maxOutputTokens).toBe(1024);
   });
 
-  it('disables Cloud Code thought output so Claude Code receives visible turns', () => {
+  it('omits the obsolete thinking budget rejected by current Gemini models', () => {
     const envelope = anthropicToCloudCode({
       max_tokens: 32000,
       output_config: { effort: 'xhigh' },
       messages: [{ role: 'user', content: 'count notebooks' }],
     }, 'gemini-3-flash-extra-low', 'project-id');
 
-    expect((envelope.request as any).generationConfig.thinkingConfig).toEqual({
-      thinkingBudget: 0,
-      includeThoughts: false,
-    });
+    expect((envelope.request as any).generationConfig.thinkingConfig).toBeUndefined();
   });
 
   it('strips JSON Schema validation keywords rejected by Cloud Code tools', () => {
@@ -58,20 +55,91 @@ describe('anthropicToCloudCode', () => {
     const parameters = request.tools[0].functionDeclarations[0].parameters;
 
     expect(parameters).toEqual({
-      type: 'object',
+      type: 'OBJECT',
       properties: {
         value: {
-          type: 'number',
+          type: 'NUMBER',
           description: 'Limit value',
         },
         mode: {
-          type: 'string',
+          type: 'STRING',
           enum: ['fast', 'safe'],
         },
       },
       required: ['value', 'mode'],
     });
     expect(JSON.stringify(parameters)).not.toContain('exclusiveMinimum');
+  });
+
+  it('normalizes JSON Schema constructs that Cloud Code Schema rejects', () => {
+    const envelope = anthropicToCloudCode({
+      max_tokens: 64,
+      messages: [{ role: 'user', content: 'use the tool' }],
+      tools: [{
+        name: 'complex_schema',
+        input_schema: {
+          properties: {
+            maybe: { type: ['string', 'null'], enum: ['yes', 2, null] },
+            tuple: {
+              type: 'array',
+              prefixItems: [{ type: 'string' }, { type: 'number' }],
+              items: [{ type: 'integer' }, { type: 'string' }],
+            },
+            inferredArray: { items: { type: 'boolean' } },
+            inferredObject: { properties: { value: { type: 'number' } } },
+            union: { anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'number' } }] },
+            referenced: { $ref: '#/$defs/Range' },
+            reservedNames: {
+              type: 'object',
+              properties: {
+                type: { type: 'string' },
+                items: { type: 'array', items: { type: 'number' } },
+              },
+            },
+          },
+          $defs: {
+            Range: {
+              type: 'object',
+              properties: { min: { type: 'integer' }, max: { type: 'integer' } },
+            },
+          },
+        },
+      }],
+    }, 'gemini-3-flash', 'project-id');
+
+    const request = envelope.request as any;
+    const parameters = request.tools[0].functionDeclarations[0].parameters;
+
+    expect(parameters).toEqual({
+      type: 'OBJECT',
+      properties: {
+        maybe: { type: 'STRING', nullable: true, enum: ['yes', '2'] },
+        tuple: { type: 'ARRAY', items: { type: 'INTEGER' } },
+        inferredArray: { items: { type: 'BOOLEAN' }, type: 'ARRAY' },
+        inferredObject: {
+          properties: { value: { type: 'NUMBER' } },
+          type: 'OBJECT',
+        },
+        union: {
+          anyOf: [
+            { type: 'STRING' },
+            { type: 'ARRAY', items: { type: 'NUMBER' } },
+          ],
+        },
+        referenced: {
+          type: 'OBJECT',
+          properties: { min: { type: 'INTEGER' }, max: { type: 'INTEGER' } },
+        },
+        reservedNames: {
+          type: 'OBJECT',
+          properties: {
+            type: { type: 'STRING' },
+            items: { type: 'ARRAY', items: { type: 'NUMBER' } },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(parameters)).not.toContain('prefixItems');
   });
 
   it('round-trips Cloud Code thought signatures on historical tool calls', async () => {


### PR DESCRIPTION
Summary:
- translate Anthropic JSON Schema into the Cloud Code Schema dialect without corrupting property names such as `type` or `items`
- normalize schema type enums, nullable unions, enum values, tuple items, local refs, object/array inference, and strip nonstandard Codex `encrypted` annotations recursively
- omit the obsolete `thinkingBudget=0` configuration rejected by current Gemini models
- lock user/assistant perspective through the Google role mapping
- lock the Antigravity user agent, Google One AI credit type, project, and model fields used in the Google request envelope

Validation:
- `npm test -- --run tests/antigravity-anthropic-to-cloudcode.test.ts` (11 passed)
- `npm run typecheck`
- `npm run build`
- live Cloud Code OAuth request with Gemini 3.6 Flash High and the full 460-tool Codex catalog returned a real response
- live Gemini 3.1 Pro request through its valid `gemini-pro-agent` slot returned a real response
- full suite: 1,637 passed, 8 skipped, 4 failed; the same four unrelated Windows failures reproduce on untouched main (two Linux-path expectations and two publish-workflow shell-shim tests)
