### PR TITLE
Honor Antigravity deprecated model aliases

### DIFF
--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -143,6 +143,24 @@ async function refreshAntigravityOAuthModels(
       if (!res.ok) continue;
       const body = await res.json() as Record<string, unknown>;
 
+      const deprecatedModelIds = body.deprecatedModelIds && typeof body.deprecatedModelIds === 'object'
+        && !Array.isArray(body.deprecatedModelIds)
+        ? body.deprecatedModelIds as Record<string, unknown>
+        : {};
+      const resolveUpstreamModelId = (id: string): string => {
+        let current = id;
+        const seen = new Set<string>();
+        while (!seen.has(current)) {
+          seen.add(current);
+          const alias = deprecatedModelIds[current];
+          if (!alias || typeof alias !== 'object' || Array.isArray(alias)) break;
+          const next = (alias as Record<string, unknown>).newModelId;
+          if (typeof next !== 'string' || next.length === 0) break;
+          current = next;
+        }
+        return current;
+      };
+
       // Response shape: { models: { [id]: { displayName, maxTokens, supportsThinking, ... } } }
       const raw: Array<Record<string, unknown> & { id: string }> = body.models && typeof body.models === 'object' && !Array.isArray(body.models)
         ? Object.entries(body.models as Record<string, Record<string, unknown>>).map(([id, model]) => ({ id, ...model }))
@@ -163,7 +181,7 @@ async function refreshAntigravityOAuthModels(
           return {
             id,
             name,
-            upstreamModelId: id,
+            upstreamModelId: resolveUpstreamModelId(id),
             family: isGemini ? 'gemini' : id.split('-')[0] ?? id,
             brand: isGemini ? 'Google' : isClaude ? 'Anthropic' : isOpenAi ? 'OpenAI' : 'Other',
             contextWindow: maxTokens ?? resolveContextWindow(id),

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -583,9 +583,22 @@ describe('registry/refresh-models', () => {
               maxTokens: 1048576,
               supportsThinking: true,
             },
+            'gemini-3.1-pro-high': {
+              displayName: 'Gemini 3.1 Pro (High)',
+              maxTokens: 1048576,
+              supportsThinking: true,
+            },
+            'gemini-pro-agent': {
+              displayName: 'Gemini 3.1 Pro (High)',
+              maxTokens: 1048576,
+              supportsThinking: true,
+            },
             tab_flash_lite_preview: {
               maxTokens: 16384,
             },
+          },
+          deprecatedModelIds: {
+            'gemini-3.1-pro-high': { newModelId: 'gemini-pro-agent' },
           },
         }),
       } as Response);
@@ -605,6 +618,8 @@ describe('registry/refresh-models', () => {
         'gemini-3.6-flash-high',
         'gemini-3.7-flash-medium',
         'gemini-3-flash',
+        'gemini-3.1-pro-high',
+        'gemini-pro-agent',
       ]);
       expect(models.map(m => m.id)).not.toContain('tab_flash_lite_preview');
       expect(models[0]).toMatchObject({
@@ -613,6 +628,9 @@ describe('registry/refresh-models', () => {
         contextWindow: 1048576,
         modelFormat: 'cloud-code',
         reasoning: true,
+      });
+      expect(models.find(model => model.id === 'gemini-3.1-pro-high')).toMatchObject({
+        upstreamModelId: 'gemini-pro-agent',
       });
     });
 


### PR DESCRIPTION
Summary:
- preserve Cloud Code deprecatedModelIds redirects during live Antigravity model refresh
- keep the picker/catalog ID stable while routing requests through Google's canonical upstream model ID
- follow chained redirects defensively and stop on cycles

Why:
Google's live catalog marks gemini-3.1-pro-high as deprecated with newModelId gemini-pro-agent. Relay previously discarded that metadata, so the friendly Pro High entry produced HTTP 400 while gemini-pro-agent worked.

Validation:
- npm test -- --run tests/registry-refresh-models.test.ts (19 passed)
- npm run typecheck
- npm run build
- live provider refresh cached gemini-3.1-pro-high with upstreamModelId gemini-pro-agent
- live gemini-pro-agent request returned a real Gemini 3.1 Pro response
- full suite: 1,631 passed, 8 skipped, 6 failed; same unrelated Windows baseline failures as main