### PR TITLE
Honor provider-qualified Codex model routes

### DIFF
--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -271,6 +271,19 @@ export function findCodexProxyRoute(
   routes: CodexProxyRoute[],
   requestedModel: string,
 ): CodexProxyRoute | undefined {
+  const bareRequestedModel = parseCodexAppModelSlug(requestedModel);
+  const providerSeparator = bareRequestedModel.indexOf('__');
+  if (providerSeparator > 0) {
+    const requestedProvider = bareRequestedModel.slice(0, providerSeparator);
+    const requestedIds = codexRouteLookupIds(bareRequestedModel.slice(providerSeparator + 2));
+    const providerRoute = routes.find(route => {
+      if (route.providerId !== requestedProvider) return false;
+      const routeIds = codexRouteLookupIds(route.modelId);
+      return requestedIds.some(id => routeIds.includes(id));
+    });
+    if (providerRoute) return providerRoute;
+  }
+
   const ids = codexRouteLookupIds(requestedModel);
   for (const id of ids) {
     const route = routes.find(r =>

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -104,6 +104,32 @@ describe('startCodexProxy', () => {
     expect(route?.modelId).toBe('grok-4.3');
   });
 
+  it('honors the provider in double underscore model ids', async () => {
+    const { findCodexProxyRoute } = await import('../src/codex-proxy.js');
+    const routes = [
+      {
+        modelId: 'shared-model',
+        providerId: 'first',
+        npm: '@ai-sdk/openai-compatible',
+        apiKey: 'first-key',
+        upstreamModelId: 'first-upstream',
+      },
+      {
+        modelId: 'shared-model',
+        providerId: 'second',
+        npm: '@ai-sdk/openai-compatible',
+        apiKey: 'second-key',
+        upstreamModelId: 'second-upstream',
+      },
+    ];
+
+    expect(findCodexProxyRoute(routes, 'second__shared-model')?.providerId).toBe('second');
+    expect(findCodexProxyRoute(
+      routes,
+      'relay-ai-launch-codex-app/second__shared-model',
+    )?.providerId).toBe('second');
+  });
+
   it('allows POST /v1/responses without auth when requireAuth is false', async () => {
     handle = await startCodexProxy([{
       modelId: 'test-model',


### PR DESCRIPTION
Summary:
- honor the provider prefix in provider__model Codex catalog IDs before performing the existing unqualified lookup
- support the same qualified IDs when wrapped in the Codex app catalog slug
- prevent duplicate model names from routing to whichever provider appears first

Validation:
- focused codex-proxy tests: 2 passed, 37 skipped
- npm run typecheck
- npm run build
- full suite: 1,632 passed, 8 skipped, 6 failed; same unrelated Windows baseline failures as main