### PR TITLE
Fix mixed Relay-to-native compaction handoff

### DIFF
--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -30,7 +30,7 @@ import { silenceSdkWarnings } from './sdk-adapter.js';
 import { formatUpstreamError, upstreamHttpStatus } from './codex/upstream-error.js';
 import { getCodexProxyDebugLogPath, makeTraceLogger, resetCodexBodyDumpLog, appendCodexBodyDump } from './trace-log.js';
 import { classifyCodexDispatch, parseMixedProxyPath } from './codex/routing.js';
-import { forwardNativeCodexHttp, allowlistedNativeHeaders, nativeResponsesWebSocketOptions, NATIVE_CODEX_RESPONSES_URL } from './codex/native-forward.js';
+import { forwardNativeCodexHttp, allowlistedNativeHeaders, nativeResponsesWebSocketOptions, prepareNativeCodexBody, NATIVE_CODEX_RESPONSES_URL } from './codex/native-forward.js';
 import {
   createNativePayloadRelay,
   resolveRoutedCollaborationInput,
@@ -1014,10 +1014,14 @@ export async function startCodexProxy(
                 return;
               }
               if (dispatch.kind === 'native') {
+                const nativeBody = prepareNativeCodexBody(body);
+                if (debug && nativeBody !== body) {
+                  log(`WS native history normalized: model=${modelId} converted Relay compaction for native verification`);
+                }
                 if (nativeActive && nativeUpstream) {
                   if (nativeUpstream.readyState === WebSocket.OPEN) {
                     if (debug) log(`WS native forwarding next turn: model=${modelId}`);
-                    nativeUpstream.send(JSON.stringify({ type: 'response.create', ...body }));
+                    nativeUpstream.send(JSON.stringify({ type: 'response.create', ...nativeBody }));
                   } else if (debug) {
                     log(`WS native cannot forward next turn: upstream_state=${nativeUpstream.readyState}`);
                   }
@@ -1070,7 +1074,7 @@ export async function startCodexProxy(
                     nativeOpened = true;
                     if (connectTimer) clearTimeout(connectTimer);
                     if (debug) log(`WS native upstream open: model=${modelId}`);
-                    upstream?.send(JSON.stringify({ type: 'response.create', ...body }));
+                    upstream?.send(JSON.stringify({ type: 'response.create', ...nativeBody }));
                     firstFrameTimer = setTimeout(() => closeBoth('Native Codex WebSocket response timed out'), 60_000);
                   });
                   upstream.once('unexpected-response', (_request, response) => {

--- a/src/codex-responses-adapter.ts
+++ b/src/codex-responses-adapter.ts
@@ -1373,8 +1373,8 @@ function encodeCompactionContent(summary: string): string {
 export function decodeCompactionContent(encrypted: string | undefined): string | null {
   if (!encrypted) return null;
   try {
-    const obj = JSON.parse(Buffer.from(encrypted, 'base64').toString('utf8')) as { summary?: unknown };
-    return typeof obj?.summary === 'string' ? obj.summary : null;
+    const obj = JSON.parse(Buffer.from(encrypted, 'base64').toString('utf8')) as { v?: unknown; summary?: unknown };
+    return obj?.v === 1 && typeof obj.summary === 'string' ? obj.summary : null;
   } catch {
     return null;
   }

--- a/src/codex/native-forward.ts
+++ b/src/codex/native-forward.ts
@@ -4,6 +4,7 @@ import {
   CODEX_RESPONSES_LITE_WS_URL,
   CODEX_RESPONSES_WEBSOCKETS_BETA,
 } from '../constants.js';
+import { decodeCompactionContent } from '../codex-responses-adapter.js';
 
 export const NATIVE_CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses';
 export const NATIVE_FORWARD_HEADERS = new Set([
@@ -58,6 +59,49 @@ export interface NativeHttpForwardOptions {
   fetchImpl?: typeof fetch;
 }
 
+/**
+ * Relay-backed models must synthesize remote-compaction-v2 items because they
+ * cannot mint OpenAI-authenticated encrypted_content. When a user switches from
+ * a Relay model to a native Codex model in the same mixed session, OpenAI cannot
+ * verify that opaque Relay item. Preserve its summary as ordinary conversation
+ * history while leaving genuine native compaction items byte-for-byte intact.
+ */
+export function prepareNativeCodexBody<T extends Record<string, unknown>>(body: T): T {
+  if (!Array.isArray(body.input)) return body;
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return item;
+    const record = item as Record<string, unknown>;
+    if (record.type !== 'compaction' && record.type !== 'context_compaction') return item;
+    const summary = decodeCompactionContent(
+      typeof record.encrypted_content === 'string' ? record.encrypted_content : undefined,
+    );
+    if (summary === null) return item;
+    changed = true;
+    return {
+      type: 'message',
+      role: 'user',
+      content: [{
+        type: 'input_text',
+        text: `[Summary of earlier conversation]\n${summary}`,
+      }],
+    };
+  });
+  return changed ? { ...body, input } : body;
+}
+
+function prepareNativeHttpBody(body: string | Uint8Array): string | Uint8Array {
+  const text = typeof body === 'string' ? body : Buffer.from(body).toString('utf8');
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return body;
+    const prepared = prepareNativeCodexBody(parsed as Record<string, unknown>);
+    return prepared === parsed ? body : JSON.stringify(prepared);
+  } catch {
+    return body;
+  }
+}
+
 export async function forwardNativeCodexHttp(options: NativeHttpForwardOptions): Promise<Response> {
   const fetchImpl = options.fetchImpl ?? fetch;
   const headers = allowlistedNativeHeaders(options.inboundHeaders);
@@ -65,7 +109,7 @@ export async function forwardNativeCodexHttp(options: NativeHttpForwardOptions):
   return fetchImpl(options.nativeUrl ?? NATIVE_CODEX_RESPONSES_URL, {
     method: 'POST',
     headers,
-    body: options.body as BodyInit,
+    body: prepareNativeHttpBody(options.body) as BodyInit,
     signal: options.signal,
     redirect: 'manual',
   });

--- a/tests/codex-native-forward.test.ts
+++ b/tests/codex-native-forward.test.ts
@@ -1,7 +1,56 @@
 import { describe, expect, it, vi } from 'vitest';
-import { forwardNativeCodexHttp, nativeResponsesWebSocketOptions, NATIVE_FORWARD_HEADERS } from '../src/codex/native-forward.js';
+import { buildCompactionResponseBody } from '../src/codex-responses-adapter.js';
+import { forwardNativeCodexHttp, nativeResponsesWebSocketOptions, prepareNativeCodexBody, NATIVE_FORWARD_HEADERS } from '../src/codex/native-forward.js';
 
 describe('native Codex forwarding', () => {
+  it('converts Relay compaction into readable native history without touching native compaction', () => {
+    const relayCompaction = (
+      buildCompactionResponseBody('fixed the parser', 'relay-model').output as Record<string, unknown>[]
+    )[0]!;
+    const nativeCompaction = {
+      type: 'compaction',
+      id: 'cmp_native',
+      encrypted_content: `gAAAAA${'A'.repeat(40)}`,
+    };
+    const original = {
+      model: 'gpt-5.6-luna',
+      input: [relayCompaction, nativeCompaction, { type: 'message', role: 'user', content: 'continue' }],
+    };
+
+    const prepared = prepareNativeCodexBody(original);
+
+    expect(prepared).not.toBe(original);
+    expect(prepared.input[0]).toEqual({
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: '[Summary of earlier conversation]\nfixed the parser' }],
+    });
+    expect(prepared.input[1]).toBe(nativeCompaction);
+    expect(original.input[0]).toBe(relayCompaction);
+  });
+
+  it('rewrites Relay compaction before HTTP native forwarding', async () => {
+    const relayCompaction = (
+      buildCompactionResponseBody('preserve this context', 'relay-model').output as Record<string, unknown>[]
+    )[0]!;
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as { input: Array<Record<string, unknown>> };
+      expect(body.input).toEqual([{
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: '[Summary of earlier conversation]\npreserve this context' }],
+      }]);
+      return new Response('ok');
+    });
+
+    await forwardNativeCodexHttp({
+      body: JSON.stringify({ model: 'gpt-5.6-luna', input: [relayCompaction] }),
+      inboundHeaders: {},
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it('forwards only allowlisted native identity headers with manual redirects', async () => {
     const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
       expect(_url).toBe('https://chatgpt.com/backend-api/codex/responses');

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -10,7 +10,7 @@ import {
   resolveCodexSubagentRoute,
   startCodexProxy,
 } from '../src/codex-proxy.js';
-import type { CodexSdkCallParams } from '../src/codex-responses-adapter.js';
+import { buildCompactionResponseBody, type CodexSdkCallParams } from '../src/codex-responses-adapter.js';
 import { CODEX_APP_AUTO_COMPACT_RATIO } from '../src/codex/app-profile.js';
 import { WebSocket, WebSocketServer } from 'ws';
 
@@ -259,12 +259,23 @@ describe('startCodexProxy', () => {
         const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`, {
           headers: { authorization: 'Bearer native', 'chatgpt-account-id': 'acct' },
         });
-        client.on('open', () => client.send(JSON.stringify({ model: 'gpt-5.5', input: 'hi' })));
+        const relayCompaction = (
+          buildCompactionResponseBody('earlier Relay work', 'relay-model').output as Record<string, unknown>[]
+        )[0]!;
+        client.on('open', () => client.send(JSON.stringify({ model: 'gpt-5.5', input: [relayCompaction] })));
         client.on('message', data => messages.push(data.toString()));
         client.on('close', () => resolve());
         client.on('error', reject);
       });
-      expect(received[0]).toMatchObject({ type: 'response.create', model: 'gpt-5.5', input: 'hi' });
+      expect(received[0]).toMatchObject({
+        type: 'response.create',
+        model: 'gpt-5.5',
+        input: [{
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: '[Summary of earlier conversation]\nearlier Relay work' }],
+        }],
+      });
       expect(messages).toContain(JSON.stringify({ type: 'response.completed', response: { status: 'completed' } }));
     } finally {
       await new Promise<void>(resolve => upstream.close(() => resolve()));

--- a/tests/codex-responses-adapter.test.ts
+++ b/tests/codex-responses-adapter.test.ts
@@ -524,6 +524,9 @@ describe('Codex remote compaction v2 synthesis (relay-ai/relay-ai#21 follow-up)'
 
   it('tolerates an undecodable encrypted_content without throwing (foreign/real-backend item)', () => {
     expect(decodeCompactionContent('not-our-base64-json')).toBeNull();
+    expect(decodeCompactionContent(
+      Buffer.from(JSON.stringify({ summary: 'foreign summary without Relay version marker' })).toString('base64'),
+    )).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- preserve Relay-generated remote-compaction summaries when a mixed Codex session switches to a native OpenAI model
- replace only Relay's version-marked synthetic compaction item with readable message history before native forwarding
- leave genuine OpenAI encrypted compaction items unchanged
- cover both HTTP forwarding and initial/subsequent Responses-Lite WebSocket frames

## Live failure reproduced
1. Start mixed Codex mode on Gemini 3.1 Pro.
2. Complete a turn and let remote compaction v2 create a durable Relay compaction item.
3. Switch in-session to native `gpt-5.6-luna`.
4. OpenAI rejects the Relay-generated item with HTTP 400 `invalid_encrypted_content`.

After this patch, Relay converts its own summary before the request crosses the native boundary, so OpenAI does not receive unverifiable ciphertext and the conversation context remains available.

## Validation
- `npm test -- --run tests/codex-native-forward.test.ts tests/codex-proxy.test.ts tests/codex-responses-adapter.test.ts` (91 passed)
- `npm run typecheck` (pass)
- `npm run build` (pass)
- full suite: 1,635 passed, 8 skipped; the same 4 pre-existing Windows test-harness failures remain (Linux path expectations and publish-workflow shims)