### PR TITLE
Fix native identity leakage into external Codex models

### DIFF
--- a/src/codex/mixed-catalog.ts
+++ b/src/codex/mixed-catalog.ts
@@ -15,6 +15,26 @@ export interface ComposeMixedCodexCatalogInput {
   externalMultiAgentVersion: 'v1' | 'v2';
 }
 
+function externalInstructionValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value
+      .replace(/^You are Codex,[^\n]*?\.\s*/i, '')
+      .replace(/\s+as Codex\b/gi, '');
+  }
+  if (Array.isArray(value)) return value.map(externalInstructionValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+      key,
+      externalInstructionValue(nested),
+    ]),
+  );
+}
+
+function externalModelMessages(templateMessages: unknown): unknown {
+  return externalInstructionValue(templateMessages);
+}
+
 function externalCatalogEntryFromTemplate(
   template: CodexCatalogModel,
   entry: MixedCatalogEntry,
@@ -30,7 +50,7 @@ function externalCatalogEntryFromTemplate(
     false,
     entry.slug,
   );
-  return {
+  const external: CodexCatalogModel = {
     ...template,
     ...generated,
     slug: entry.slug,
@@ -38,6 +58,12 @@ function externalCatalogEntryFromTemplate(
     visibility,
     multi_agent_version: multiAgentVersion,
   };
+  // Keep generic Codex agent behavior without copying native-model identity
+  // claims into an external model. The native comp_hash no longer describes
+  // the sanitized instructions and must not be advertised for this entry.
+  external.model_messages = externalModelMessages(template.model_messages);
+  delete external.comp_hash;
+  return external;
 }
 
 export function composeMixedCodexCatalog(input: ComposeMixedCodexCatalogInput): CodexCatalogFile {

--- a/tests/codex-mixed-catalog.test.ts
+++ b/tests/codex-mixed-catalog.test.ts
@@ -10,6 +10,15 @@ const native = {
   base_instructions: 'native', supports_reasoning_summaries: true, support_verbosity: false,
   default_verbosity: null, apply_patch_tool_type: null, truncation_policy: { mode: 'tokens', limit: 1000 },
   supports_parallel_tool_calls: true, experimental_supported_tools: [], multi_agent_version: 'v2',
+  model_messages: {
+    instructions_template: 'You are Codex, a coding agent. You and the user share one workspace.',
+    instructions_variables: {
+      personality_friendly: 'You have a vivid inner life as Codex: curious and present.',
+      tool_guidance: 'Use the Codex app tools carefully.',
+    },
+    approvals: { allow: true },
+  },
+  comp_hash: 'native-instruction-hash',
   nested_unknown: { stable: true },
 };
 
@@ -36,6 +45,20 @@ describe('mixed Codex catalog composition', () => {
     expect(catalog.models.find(m => m.slug === 'kilo__auto')?.multi_agent_version).toBe('v2');
     expect(catalog.models.find(m => m.slug === 'google__gemini')?.multi_agent_version).toBe('v2');
     expect(catalog.models.find(m => m.slug === 'kilo__auto')?.nested_unknown).toEqual({ stable: true });
+    expect(catalog.models[0]?.model_messages).toEqual(native.model_messages);
+    expect(catalog.models[0]?.comp_hash).toBe('native-instruction-hash');
+
+    const external = catalog.models.find(m => m.slug === 'google__gemini');
+    expect((external?.model_messages as any)?.instructions_template).toBe(
+      'You and the user share one workspace.',
+    );
+    expect((external?.model_messages as any)?.instructions_variables).toEqual({
+      personality_friendly: 'You have a vivid inner life: curious and present.',
+      tool_guidance: 'Use the Codex app tools carefully.',
+    });
+    expect((external?.model_messages as any)?.approvals).toEqual({ allow: true });
+    expect(external?.comp_hash).toBeUndefined();
+    expect(JSON.stringify(external)).not.toMatch(/You are Codex|as Codex/i);
   });
 
   it('deduplicates a sub-agent entry already visible', () => {


### PR DESCRIPTION
## What changed

- sanitize inherited `model_messages` for external mixed-catalog entries
- remove native identity claims such as `You are Codex...` and `as Codex`
- preserve generic Codex workspace/tool guidance and all native catalog entries
- remove the native `comp_hash` from the modified external instruction package

## Why

Relay builds external picker entries from a native Codex catalog template. The template contains model-specific OpenAI/Codex identity text and a hash for those exact instructions. Copying both to Gemini, Claude, or another external model creates contradictory identity prompts and advertises a stale hash.

The fix does not inject a replacement provider or model identity. It only removes the native identity claims from external entries.

## Validation

- `npm test -- --run tests/codex-mixed-catalog.test.ts`
- `npm run typecheck`
- `npm run build`
- clean tarball install and CLI launch from an isolated npm prefix
- live regenerated catalog audit: all four external entries retained `model_messages`, contained no `You are Codex` / `as Codex` claims, and had no native `comp_hash`
- live Codex Desktop picker test: Gemini 3.1 Pro returned the exact requested marker; Relay recorded outer model `antigravity__gemini-3.1-pro-high` and Google route `gemini-pro-agent`
- live same-task continuity test: after the Gemini response, switching back to native GPT-5.6 Sol returned the exact requested marker; the task rollout recorded `reasoning_effort: high`

Regression coverage verifies that native entries remain unchanged, nested external instruction variables are copied rather than mutated, operational Codex references remain available, false identity claims are absent, and the stale external `comp_hash` is removed.
