### PR TITLE
feat(codex-app): support unattended launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,8 @@ Launch the **ChatGPT app in Codex mode** (macOS, Windows, or Linux) with registr
 relay-ai codex-app
 ```
 
+Unattended launches must be fully specified: `relay-ai codex-app --provider <id> --model <id> --with-native --yes` (or use `--relay-only`).
+
 Patches `~/.codex/config.toml` with backup; **Ctrl+C** in the relay-ai terminal asks whether to close ChatGPT Desktop and restore your config (choose "No, keep session running" to decline and keep going). The app keeps Codex's built-in `openai` provider active so existing conversation history remains visible, and routes the selected model through a foreground local proxy. Preview config without writing: `relay-ai codex-app --config`. Recovery: `relay-ai codex-app --restore`.
 
 On Linux, Relay supports the packaged ChatGPT desktop app at `/usr/bin/chatgpt` or `/usr/lib/chatgpt/ChatGPT`. When launched from an X11/RDP terminal, Relay uses that terminal's window identity to resolve the active display, so the app opens in the current graphical session even when the inherited `DISPLAY` value is stale. Keep the Relay terminal open while using the app; it owns the local proxy.

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -146,6 +146,16 @@ On macOS, profile TOML alone may not be enough; relay-ai also passes `-s danger-
 relay-ai codex-app
 ```
 
+For unattended startup, specify every launch choice and add `--yes`:
+
+```bash
+relay-ai codex-app --provider antigravity --model gemini-3.1-pro-high --with-native --yes
+```
+
+`--yes` bypasses the launch and restart confirmations. To prevent an unattended
+launch from relying on saved or default choices, it requires `--provider`,
+`--model`, and either `--with-native` or `--relay-only`.
+
 Pick provider → pick model → Codex **app** opens. **Keep the relay-ai terminal open** until you’re done (the app always uses the foreground proxy). Press **Ctrl+C** to stop the proxy and restore your previous Codex config.
 
 **Platforms:** macOS, Windows, and Linux. On Linux, Relay detects the packaged ChatGPT app at `/usr/bin/chatgpt` or `/usr/lib/chatgpt/ChatGPT` and its embedded Codex runtime at `/usr/lib/chatgpt/resources/codex`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,6 +270,7 @@ export function parseArgs(args: string[]): ParsedArgs {
       if (arg === '--help' || arg === '-h') { parsed.showHelp = true; continue; }
       if (arg === '--version' || arg === '-v') { parsed.showVersion = true; continue; }
       if (arg === '--vertex') { parsed.vertex = true; continue; }
+      if (arg === '--yes' || arg === '-y') { parsed.assumeYes = true; continue; }
       if (arg === '--with-native') {
         if (parsed.codexLaunchMode === 'relay-only') parsed.error = '--with-native and --relay-only cannot be used together';
         parsed.codexLaunchMode = 'mixed';
@@ -1762,7 +1763,7 @@ Options:
       console.log(codexAppHelpText());
       return 0;
     }
-    return runCodexAppCommand(parsed.claudeArgs, { vertex: parsed.vertex, launchProvider: parsed.launchProvider, launchModel: parsed.launchModel, codexLaunchMode: parsed.codexLaunchMode });
+    return runCodexAppCommand(parsed.claudeArgs, { vertex: parsed.vertex, launchProvider: parsed.launchProvider, launchModel: parsed.launchModel, codexLaunchMode: parsed.codexLaunchMode, assumeYes: parsed.assumeYes });
   }
 
   if (parsed.command === 'claude-app') {

--- a/src/codex-app.ts
+++ b/src/codex-app.ts
@@ -138,6 +138,7 @@ ${pc.bold('Options:')}
   --vertex     Use Claude models through Google Vertex AI
   --with-native Load native Codex models beside Relay models for this launch
   --relay-only Keep the current Relay-only launch behavior
+  --yes, -y     Approve a fully specified launch/restart without prompting
   --restore    Restore Codex config after an interrupted app session
   --config     Preview the generated Codex app configuration without launching
   --trace      Write proxy debug logs to ~/.relay-ai/logs/ and show errors on exit
@@ -164,6 +165,7 @@ ${pc.bold('Preview (no writes):')}
 ${pc.bold('Examples:')}
   relay-ai codex-app
   relay-ai codex-app --vertex
+  relay-ai codex-app --provider antigravity --model gemini-3.1-pro-high --with-native --yes
   relay-ai codex-app --config
   relay-ai codex-app --restore
   
@@ -330,7 +332,7 @@ async function runCodexAppVertexLaunch(configOnly: boolean, trace = false): Prom
   }
 }
 
-export async function runCodexAppCommand(args: string[], opts: { vertex?: boolean; launchProvider?: string; launchModel?: string; codexLaunchMode?: 'mixed' | 'relay-only' } = {}): Promise<number> {
+export async function runCodexAppCommand(args: string[], opts: { vertex?: boolean; launchProvider?: string; launchModel?: string; codexLaunchMode?: 'mixed' | 'relay-only'; assumeYes?: boolean } = {}): Promise<number> {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(codexAppHelpText());
     return 0;
@@ -342,6 +344,14 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     return result.liveSession ? 1 : 0;
   }
 
+  const configOnly = args.includes('--config');
+  if (opts.assumeYes && !configOnly) {
+    if (opts.vertex || !opts.launchProvider || !opts.launchModel || !opts.codexLaunchMode) {
+      console.error(pc.red('--yes requires --provider, --model, and either --with-native or --relay-only.'));
+      return 1;
+    }
+  }
+
   try {
     codexAppSupported();
   } catch (err) {
@@ -350,7 +360,6 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
   }
 
   const interrupted = recoverInterruptedCodexAppSession();
-  const configOnly = args.includes('--config');
   const trace = args.includes('--trace');
   const debugLogPath = getCodexProxyDebugLogPath();
   if (trace && !configOnly) {
@@ -359,7 +368,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
 
   const isTty = Boolean(process.stdin.isTTY);
   if (!configOnly) {
-    const sessionCheck = checkAppSessionLock(isTty);
+    const sessionCheck = checkAppSessionLock(isTty || Boolean(opts.assumeYes));
     if (!sessionCheck.ok) {
       if (sessionCheck.reason === 'non_tty') {
         console.error(pc.red('relay-ai codex-app requires an interactive terminal.'));
@@ -542,7 +551,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     }
   }
 
-  if (!configOnly) {
+  if (!configOnly && !opts.assumeYes) {
     const modelLabel = formatCodexModelLabel(selectedModel);
     const confirmed = await confirmCodexLaunch(
       activeProvider.name,
@@ -746,7 +755,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     logCodexActiveModel(modelLabel, selectedModel.id);
 
     try {
-      await launchOrRestartCodexApp();
+      await launchOrRestartCodexApp(undefined, opts.assumeYes);
     } catch (err) {
       p.log.warn(String(err instanceof Error ? err.message : err));
       p.log.info(codexAppInstallHint());

--- a/src/codex/app-launch.ts
+++ b/src/codex/app-launch.ts
@@ -298,6 +298,7 @@ function winForceQuit(): void {
 
 export async function launchOrRestartCodexApp(
   prompt = 'Restart ChatGPT Desktop to apply relay-ai settings?',
+  assumeYes = false,
 ): Promise<void> {
   const appPath = findCodexApp();
   if (!isCodexAppRunning()) {
@@ -317,6 +318,9 @@ export async function launchOrRestartCodexApp(
   if (process.platform === 'linux') {
     p.log.info('Restarting ChatGPT Desktop to apply relay-ai settings...');
     linuxQuitGraceful();
+  } else if (assumeYes) {
+    if (process.platform === 'darwin') darwinQuit();
+    else if (process.platform === 'win32') winQuitGraceful();
   } else {
     const restart = await p.confirm({ message: prompt, initialValue: true });
     if (p.isCancel(restart) || !restart) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export interface ParsedArgs {
   launchProvider?: string;
   /** relay-ai boot model (claude/codex); not passed to child CLI */
   launchModel?: string;
+  /** Approve a fully specified Codex App launch without interactive prompts. */
+  assumeYes?: boolean;
   /** Print comprehensive AI agent reference (relay-ai --ai) */
   showAi?: boolean;
   /** Install --ai SKILL.md to agent skill directories */

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -100,6 +100,19 @@ describe('parseArgs', () => {
     });
   });
 
+  it('consumes the non-interactive Codex App confirmation flag', () => {
+    expect(parseArgs(['codex-app', '--yes'])).toMatchObject({
+      command: 'codex-app',
+      assumeYes: true,
+      claudeArgs: [],
+    });
+    expect(parseArgs(['chatgpt', '-y'])).toMatchObject({
+      command: 'codex-app',
+      assumeYes: true,
+      claudeArgs: [],
+    });
+  });
+
   it('parses codex command', () => {
     expect(parseArgs(['codex'])).toMatchObject({
       command: 'codex',
@@ -550,7 +563,17 @@ describe('main routing', () => {
     await expect(main(['codex-app', '--help'])).resolves.toBe(0);
     expect(log.mock.calls.flat().join('\n')).toContain('relay-ai codex-app');
     expect(log.mock.calls.flat().join('\n')).toContain('Linux');
+    expect(log.mock.calls.flat().join('\n')).toContain('--yes');
     expect(error).not.toHaveBeenCalled();
+  });
+
+  it('rejects ambiguous non-interactive Codex App launches', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(main(['codex-app', '--yes'])).resolves.toBe(1);
+    expect(error.mock.calls.flat().join('\n')).toContain(
+      '--yes requires --provider, --model, and either --with-native or --relay-only',
+    );
   });
 
   it('resets and prints the provider trace for providers --trace', async () => {


### PR DESCRIPTION
## Summary
- add a guarded `--yes` / `-y` option for unattended ChatGPT/Codex desktop launches
- require explicit provider, model, and mixed/Relay-only mode before prompts may be bypassed
- approve an already-running app restart only when the caller explicitly uses `--yes`
- document the unattended startup command in README and the Codex guide

## Why
Scheduled/background launches currently stop at hidden interactive confirmations, so the process appears to start but never patches Codex config or opens the app.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm test -- --run tests/cli.test.ts tests/codex-app-session.test.ts tests/codex-app-shutdown.test.ts` (69 passed)
- built CLI help and ambiguous `--yes` rejection checked directly

Full Windows suite: 1634 passed, 8 skipped; existing platform/harness failures remain in Linux path assertions and publish-workflow stubs, plus one transient native-launcher timeout. No failures were introduced in the focused path.