### PR TITLE
fix(codex-app): startup readiness probe, external runtime identity, and macOS lifecycle hardening

### DIFF
--- a/dist/chunk-OIYXDMMG.js
+++ b/dist/chunk-OIYXDMMG.js
@@ -12888,6 +12888,7 @@ ${pc6.bold("Usage:")}
   relay-ai providers auth openai-oauth
   relay-ai providers auth github-copilot
   relay-ai providers auth cline-pass
+  relay-ai providers auth antigravity
 
 ${pc6.bold("Device code (works on SSH/VPS):")}
   xai-oauth        SuperGrok / X Premium (device code at x.ai/device)
@@ -12895,11 +12896,14 @@ ${pc6.bold("Device code (works on SSH/VPS):")}
   github-copilot   GitHub Copilot Free or paid (device code at github.com/login/device)
   cline-pass       ClinePass account (device code at app.cline.bot)
 
+${pc6.bold("Browser sign-in:")}
+  antigravity      Google Cloud Code Assist OAuth (opens Google sign-in)
+
 ${pc6.dim("OpenCode CLI configs: use")} relay-ai providers import${pc6.dim(" (optional one-time migration).")}`;
 }
 
 // src/codex/app-launch.ts
-import { execSync as execSync2, spawn as spawn3 } from "child_process";
+import { execFileSync as execFileSync3, execSync as execSync2, spawn as spawn3 } from "child_process";
 import { copyFileSync as copyFileSync3, existsSync as existsSync11, mkdirSync as mkdirSync8, readdirSync as readdirSync2, realpathSync, statSync as statSync3 } from "fs";
 import { homedir as homedir7 } from "os";
 import { dirname as dirname5, join as join12, win32 as winPath } from "path";
@@ -13136,6 +13140,43 @@ function darwinIsRunning() {
     }
   });
 }
+function pgrepExact(names) {
+  const pids = /* @__PURE__ */ new Set();
+  for (const name of names) {
+    try {
+      for (const raw of run(`pgrep -x ${JSON.stringify(name)}`).split(/\s+/)) {
+        const pid = Number.parseInt(raw, 10);
+        if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) pids.add(pid);
+      }
+    } catch {
+    }
+  }
+  return [...pids];
+}
+function darwinMainExecutableCandidates(appPath) {
+  return DARWIN_APP_NAMES.map((name) => join12(appPath, "Contents", "MacOS", name));
+}
+function pgrepExactCommand(commands) {
+  const pids = /* @__PURE__ */ new Set();
+  for (const command of commands) {
+    try {
+      const out = execFileSync3("pgrep", ["-f", `^${command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`], {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"]
+      }).trim();
+      for (const raw of out.split(/\s+/)) {
+        const pid = Number.parseInt(raw, 10);
+        if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) pids.add(pid);
+      }
+    } catch {
+    }
+  }
+  return [...pids];
+}
+function darwinMatchingPids() {
+  const appPath = findCodexApp("darwin");
+  return appPath ? pgrepExactCommand(darwinMainExecutableCandidates(appPath)) : [];
+}
 function linuxIsRunning() {
   for (const name of ["ChatGPT", "chatgpt"]) {
     try {
@@ -13144,6 +13185,9 @@ function linuxIsRunning() {
     }
   }
   return false;
+}
+function linuxMatchingPids() {
+  return pgrepExact(["ChatGPT", "chatgpt"]);
 }
 function winMatchingPids() {
   try {
@@ -13173,21 +13217,30 @@ function isCodexAppRunning() {
   if (process.platform === "linux") return linuxIsRunning();
   return false;
 }
+function codexAppMainPids(platform = process.platform) {
+  if (platform === "darwin") return darwinMatchingPids();
+  if (platform === "win32") return winMatchingPids();
+  if (platform === "linux") return linuxMatchingPids();
+  return [];
+}
+function pidIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-async function waitForQuit(timeoutMs) {
+async function waitForOriginalCodexPids(originalPids, timeoutMs, alive = pidIsAlive) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (process.platform === "win32") {
-      if (winMatchingPids().length === 0) return true;
-    } else if (process.platform === "linux" ? !linuxIsRunning() : !darwinIsRunning()) {
-      return true;
-    }
+    if (originalPids.every((pid) => !alive(pid))) return true;
     await sleep(200);
   }
-  if (process.platform === "win32") return winMatchingPids().length === 0;
-  return process.platform === "linux" ? !linuxIsRunning() : !darwinIsRunning();
+  return originalPids.every((pid) => !alive(pid));
 }
 function openCodexAppAt(path) {
   if (process.platform === "darwin") {
@@ -13219,12 +13272,11 @@ function openCodexApp() {
   }
   openCodexAppAt(path);
 }
+function darwinQuitAppleScript() {
+  return `tell application id "${CODEX_BUNDLE_ID}" to quit`;
+}
 function darwinQuit() {
-  try {
-    execSync2(`osascript -e 'tell application "Codex" to quit'`, { stdio: "pipe" });
-  } catch {
-    execSync2(`osascript -e 'tell application id "${CODEX_BUNDLE_ID}" to quit'`, { stdio: "pipe" });
-  }
+  execFileSync3("osascript", ["-e", darwinQuitAppleScript()], { stdio: "pipe" });
 }
 function winQuitGraceful() {
   const nameFilter = WIN_APP_NAMES.map((name) => `'${name}'`).join(",");
@@ -13246,13 +13298,19 @@ function quitCodexAppGracefully() {
   else if (process.platform === "win32") winQuitGraceful();
   else if (process.platform === "linux") linuxQuitGraceful();
 }
-function winForceQuit() {
-  const pids = winMatchingPids();
+function winForceQuit(pids = winMatchingPids()) {
   if (pids.length === 0) return;
   runPowerShell(`Stop-Process -Id ${pids.join(",")} -Force -ErrorAction SilentlyContinue`);
 }
+function restartTimeoutAction(platform) {
+  return platform === "win32" ? "force-quit" : "fail-closed";
+}
+function gracefulQuitTimeoutMs(platform) {
+  return platform === "darwin" ? 3e4 : 5e3;
+}
 async function launchOrRestartCodexApp(prompt = "Restart ChatGPT Desktop to apply relay-ai settings?", assumeYes = false) {
   const appPath = findCodexApp();
+  const originalPids = codexAppMainPids();
   if (!isCodexAppRunning()) {
     if (!appPath) {
       throw new Error(
@@ -13261,6 +13319,9 @@ async function launchOrRestartCodexApp(prompt = "Restart ChatGPT Desktop to appl
     }
     openCodexAppAt(appPath);
     return;
+  }
+  if (originalPids.length === 0) {
+    throw new Error("ChatGPT Desktop is running but Relay could not identify its main process; refusing an unsafe restart.");
   }
   if (process.platform === "linux") {
     p6.log.info("Restarting ChatGPT Desktop to apply relay-ai settings...");
@@ -13277,10 +13338,18 @@ async function launchOrRestartCodexApp(prompt = "Restart ChatGPT Desktop to appl
     if (process.platform === "darwin") darwinQuit();
     else if (process.platform === "win32") winQuitGraceful();
   }
-  if (!await waitForQuit(5e3)) {
-    if (process.platform === "win32") winForceQuit();
-    await waitForQuit(5e3);
+  const gracefulTimeout = gracefulQuitTimeoutMs(process.platform);
+  if (!await waitForOriginalCodexPids(originalPids, gracefulTimeout)) {
+    if (restartTimeoutAction(process.platform) === "force-quit") {
+      winForceQuit(originalPids);
+      if (!await waitForOriginalCodexPids(originalPids, 5e3)) {
+        throw new Error("ChatGPT Desktop did not exit after its force-quit timeout; refusing to launch a duplicate process.");
+      }
+    } else {
+      throw new Error("ChatGPT Desktop did not exit after graceful shutdown; refusing to relaunch or force-quit it.");
+    }
   }
+  if (isCodexAppRunning()) return;
   if (appPath) openCodexAppAt(appPath);
   else openCodexApp();
 }
@@ -13356,7 +13425,7 @@ function linuxWhichClaude() {
     return null;
   }
 }
-function linuxMatchingPids() {
+function linuxMatchingPids2() {
   try {
     const out = run2("pgrep -x claude-desktop");
     return out.split(/\s+/).map((s) => Number.parseInt(s, 10)).filter((n) => Number.isFinite(n) && n > 0);
@@ -13365,7 +13434,7 @@ function linuxMatchingPids() {
   }
 }
 function linuxMainPid() {
-  const pids = linuxMatchingPids();
+  const pids = linuxMatchingPids2();
   for (const pid of pids) {
     try {
       const cmdline = readFileSync12(`/proc/${pid}/cmdline`, "utf8");
@@ -13384,7 +13453,7 @@ function linuxQuit() {
   }
 }
 function linuxForceQuit() {
-  for (const pid of linuxMatchingPids()) {
+  for (const pid of linuxMatchingPids2()) {
     try {
       process.kill(pid, "SIGKILL");
     } catch {
@@ -13463,26 +13532,26 @@ function winHasWindow2() {
 function isClaudeAppRunning() {
   if (process.platform === "darwin") return darwinIsRunning2();
   if (process.platform === "win32") return winMatchingPids2().length > 0 || winHasWindow2();
-  if (process.platform === "linux") return linuxMatchingPids().length > 0;
+  if (process.platform === "linux") return linuxMatchingPids2().length > 0;
   return false;
 }
 function sleep2(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-async function waitForQuit2(timeoutMs) {
+async function waitForQuit(timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (process.platform === "win32") {
       if (winMatchingPids2().length === 0) return true;
     } else if (process.platform === "linux") {
-      if (linuxMatchingPids().length === 0) return true;
+      if (linuxMatchingPids2().length === 0) return true;
     } else if (!darwinIsRunning2()) {
       return true;
     }
     await sleep2(200);
   }
   if (process.platform === "win32") return winMatchingPids2().length === 0;
-  if (process.platform === "linux") return linuxMatchingPids().length === 0;
+  if (process.platform === "linux") return linuxMatchingPids2().length === 0;
   return !darwinIsRunning2();
 }
 function openClaudeAppAt(path) {
@@ -13558,10 +13627,10 @@ async function launchOrRestartClaudeApp(prompt = "Restart Claude Desktop to appl
     if (process.platform === "darwin") darwinQuit2();
     else if (process.platform === "win32") winQuitGraceful2();
   }
-  if (!await waitForQuit2(5e3)) {
+  if (!await waitForQuit(5e3)) {
     if (process.platform === "win32") winForceQuit2();
     else if (process.platform === "linux") linuxForceQuit();
-    await waitForQuit2(5e3);
+    await waitForQuit(5e3);
   }
   if (appPath) openClaudeAppAt(appPath);
   else openClaudeApp();
@@ -13631,6 +13700,7 @@ export {
   getAppHome,
   getConfigPath,
   getProvidersPath,
+  getLogsPath,
   loadPreferences,
   savePreferences,
   getAppPathOverride,
@@ -13818,4 +13888,4 @@ export {
   supportsClaudeTransparentMode,
   buildHttpProxyRoutes
 };
-//# sourceMappingURL=chunk-SCW2TYSG.js.map
+//# sourceMappingURL=chunk-OIYXDMMG.js.map

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -11541,10 +11541,11 @@ function codexAppUsesExplicitSelection(configOnly, launchProvider, launchModel) 
   void configOnly;
   return Boolean(launchProvider && launchModel);
 }
-async function waitForShutdownWithConfirm() {
+async function waitForShutdownWithConfirm(assumeYes = false) {
   while (true) {
     const signal = await waitForShutdown2();
     if (signal !== "sigint") return signal;
+    if (assumeYes) return signal;
     console.log("");
     const choice = await p12.select({
       message: "Close ChatGPT Desktop and restore your Codex config?",
@@ -11559,8 +11560,13 @@ async function waitForShutdownWithConfirm() {
 function unattendedShutdownClosesApp(assumeYes, signal) {
   return assumeYes && signal !== "sigint";
 }
-async function maybeCloseRunningCodexApp() {
+async function maybeCloseRunningCodexApp(assumeYes = false) {
   if (!isCodexAppRunning()) return;
+  if (assumeYes) {
+    p12.log.step("Stopping ChatGPT Desktop...");
+    quitCodexAppGracefully();
+    return;
+  }
   const shouldClose = await p12.confirm({ message: "ChatGPT Desktop is still running. Close it?" });
   if (shouldClose && !p12.isCancel(shouldClose)) {
     p12.log.step("Stopping ChatGPT Desktop...");
@@ -12152,7 +12158,7 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
       restoreCommand: "relay-ai codex-app --restore"
     });
     codexAppOutro(modelLabel);
-    const shutdownSignal = await waitForShutdownWithConfirm();
+    const shutdownSignal = await waitForShutdownWithConfirm(opts.assumeYes);
     if (trace) printTraceLog(debugLogPath);
     console.log("");
     if (sessionActive) {
@@ -12165,7 +12171,7 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
         quitCodexAppGracefully();
       }
     } else {
-      await maybeCloseRunningCodexApp();
+      await maybeCloseRunningCodexApp(opts.assumeYes);
     }
     return 0;
   } finally {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -84,6 +84,7 @@ import {
   getCodexProxyDebugLogPath,
   getConfigPath,
   getGeminiProxyDebugLogPath,
+  getLogsPath,
   getProvidersPath,
   getProxyDebugLogPath,
   getReasoningCapabilities,
@@ -197,7 +198,7 @@ import {
   validateCustomEndpointUrl,
   writeSecureLogLine,
   zenRegistryStub
-} from "./chunk-SCW2TYSG.js";
+} from "./chunk-OIYXDMMG.js";
 import {
   filterTemplates,
   getTemplateById,
@@ -1295,7 +1296,7 @@ ${pc4.bold("Subcommands:")}
   (none)      Provider hub wizard ${pc4.dim("[Phase 1.1]")}
   add         Add a provider (Groq, Mistral, Together AI, \u2026) ${pc4.dim("[Phase 1.1]")}
   import      Optional one-time import from OpenCode CLI ${pc4.dim("[Phase 1.0]")}
-  auth        Sign in with OAuth (GitHub Copilot, xAI, OpenAI, ClinePass)
+  auth        Sign in with OAuth (Antigravity, GitHub Copilot, xAI, OpenAI, ClinePass)
   list        Show configured providers ${pc4.dim("[Phase 1.0]")}
   remove      Remove a provider by id ${pc4.dim("[Phase 1.1]")}
   refresh-models  Update cached model lists ${pc4.dim("[Phase 1.2]")}`;
@@ -2233,7 +2234,7 @@ async function runProvidersCommand(args) {
 // src/codex.ts
 import pc7 from "picocolors";
 import * as p8 from "@clack/prompts";
-import { join as join5 } from "path";
+import { join as join6 } from "path";
 
 // src/codex-proxy.ts
 import { createHash as createHash2 } from "crypto";
@@ -3770,6 +3771,53 @@ async function resolveRoutedCollaborationInput(input, context) {
   return normalizePlaintextCollaborationForExternal(out);
 }
 
+// src/codex/route-audit.ts
+import { chmodSync, mkdirSync, writeFileSync } from "fs";
+import { join as join2 } from "path";
+var DIR_MODE = 448;
+var FILE_MODE = 384;
+var CODEX_ROUTE_AUDIT_LOG = "codex-route-audit.jsonl";
+function safeIdentifier(value) {
+  if (value === void 0) return void 0;
+  return value.replace(/[\u0000-\u001f\u007f]/g, "_").slice(0, 300);
+}
+function sanitizeCodexRouteAuditEvent(event) {
+  return {
+    ts: (/* @__PURE__ */ new Date()).toISOString(),
+    transport: event.transport,
+    requestedModel: safeIdentifier(event.requestedModel),
+    dispatch: event.dispatch,
+    phase: event.phase,
+    ...event.provider ? { provider: safeIdentifier(event.provider) } : {},
+    ...event.routeModel ? { routeModel: safeIdentifier(event.routeModel) } : {},
+    ...event.upstreamModel ? { upstreamModel: safeIdentifier(event.upstreamModel) } : {},
+    ...event.outcome ? { outcome: event.outcome } : {},
+    ...event.status !== void 0 ? { status: typeof event.status === "string" ? safeIdentifier(event.status) : event.status } : {}
+  };
+}
+function getCodexRouteAuditLogPath() {
+  const dir = getLogsPath();
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  try {
+    chmodSync(dir, DIR_MODE);
+  } catch {
+  }
+  return join2(dir, CODEX_ROUTE_AUDIT_LOG);
+}
+function prepareCodexRouteAuditLog(path3 = getCodexRouteAuditLogPath()) {
+  writeFileSync(path3, "", { mode: FILE_MODE });
+  chmodSync(path3, FILE_MODE);
+  return path3;
+}
+function appendCodexRouteAudit(path3, event) {
+  try {
+    writeFileSync(path3, `${JSON.stringify(sanitizeCodexRouteAuditEvent(event))}
+`, { flag: "a", mode: FILE_MODE });
+    chmodSync(path3, FILE_MODE);
+  } catch {
+  }
+}
+
 // src/codex-proxy.ts
 function captureCompletedResponse(sseText) {
   if (!sseText.includes("response.completed")) return void 0;
@@ -3980,11 +4028,32 @@ async function prepareExternalCodexBody(body, context) {
   );
   return { ...externalBody, input: resolvedInput };
 }
+function applyExternalCodexRuntimeIdentity(params, route) {
+  const selectedModel = route.auditUpstreamModelId ?? route.upstreamModelId ?? route.modelId;
+  const provider = route.providerId ?? "relay";
+  const identity = [
+    "<external-model-identity>",
+    `The selected model for this turn is ${JSON.stringify(selectedModel)} through provider ${JSON.stringify(provider)}.`,
+    "Codex is the host application and agent environment, not the model identity.",
+    "Follow Codex host and tool instructions normally, but do not infer that you are an OpenAI or GPT model from host names, tool names, documentation, or conversation context.",
+    "If asked what model you are, report the selected model and provider above; do not use self-identification as evidence of the network route.",
+    "</external-model-identity>"
+  ].join("\n");
+  return {
+    ...params,
+    system: params.system?.trim() ? `${identity}
+
+${params.system}` : identity
+  };
+}
 async function startCodexProxy(routes, options = {}) {
   const opts = typeof options === "boolean" ? { debug: options } : options;
   const debug = opts.debug ?? false;
   const requireAuth = opts.requireAuth ?? true;
   const mixedNative = opts.mixedNative;
+  const audit = (event) => {
+    if (opts.routeAuditPath) appendCodexRouteAudit(opts.routeAuditPath, event);
+  };
   const nativePayloadRelay = mixedNative ? createNativePayloadRelay({}) : void 0;
   silenceSdkWarnings();
   const models = /* @__PURE__ */ new Map();
@@ -4158,6 +4227,7 @@ async function startCodexProxy(routes, options = {}) {
           log14(`subagent dispatch: requested=${modelId} route=${subagentRoute?.modelId ?? "(none)"}`);
         }
         if (mixedNative && markedSubagent && !subagentRoute) {
+          audit({ transport: "http", requestedModel: modelId, dispatch: "relay-subagent", phase: "complete", outcome: "error", status: 503 });
           sendJson(res, 503, {
             error: {
               message: "Codex marked this request as a Sub-agent, but no configured Codex Sub-agent route is available.",
@@ -4170,10 +4240,20 @@ async function startCodexProxy(routes, options = {}) {
           if (!markedSubagent) {
             const dispatch = classifyCodexDispatch(modelId, routes, mixedNative.nativeModelIds);
             if (dispatch.kind === "unknown") {
+              audit({ transport: "http", requestedModel: modelId, dispatch: "unknown", phase: "complete", outcome: "error", status: 404 });
               sendJson(res, 404, { error: { message: `Unknown model: ${modelId}`, type: "invalid_request_error" } });
               return;
             }
             if (dispatch.kind === "native") {
+              audit({
+                transport: "http",
+                requestedModel: modelId,
+                dispatch: "native",
+                phase: "dispatch",
+                provider: "openai-native",
+                routeModel: modelId,
+                upstreamModel: modelId
+              });
               const controller = new AbortController();
               req.once("aborted", () => controller.abort());
               try {
@@ -4187,7 +4267,29 @@ async function startCodexProxy(routes, options = {}) {
                 const contentType = nativeResponse.headers.get("content-type");
                 res.writeHead(nativeResponse.status, contentType ? { "content-type": contentType } : void 0);
                 res.end(Buffer.from(await nativeResponse.arrayBuffer()));
+                audit({
+                  transport: "http",
+                  requestedModel: modelId,
+                  dispatch: "native",
+                  phase: "complete",
+                  provider: "openai-native",
+                  routeModel: modelId,
+                  upstreamModel: modelId,
+                  outcome: nativeResponse.ok ? "ok" : "error",
+                  status: nativeResponse.status
+                });
               } catch (err) {
+                audit({
+                  transport: "http",
+                  requestedModel: modelId,
+                  dispatch: "native",
+                  phase: "complete",
+                  provider: "openai-native",
+                  routeModel: modelId,
+                  upstreamModel: modelId,
+                  outcome: "error",
+                  status: "forward-failed"
+                });
                 if (!res.writableEnded) sendJson(res, 502, { error: { message: "Native Codex request failed", type: "upstream_error" } });
               }
               return;
@@ -4212,13 +4314,23 @@ async function startCodexProxy(routes, options = {}) {
           }
         }
         const { route, languageModel } = resolved;
+        const relayDispatch = markedSubagent ? "relay-subagent" : "relay";
+        audit({
+          transport: "http",
+          requestedModel: modelId,
+          dispatch: relayDispatch,
+          phase: "dispatch",
+          provider: route.providerId ?? "relay",
+          routeModel: route.modelId,
+          upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId
+        });
         try {
           const routedBody = await prepareExternalCodexBody(body, {
             relay: nativePayloadRelay,
             mixedNative,
             headers: req.headers
           });
-          let params = applyClaudeCodeOAuthIdentity(route, translateResponsesRequest(
+          let params = applyClaudeCodeOAuthIdentity(route, applyExternalCodexRuntimeIdentity(translateResponsesRequest(
             routedBody,
             route.npm,
             {
@@ -4230,7 +4342,7 @@ async function startCodexProxy(routes, options = {}) {
               upstreamModelId: route.upstreamModelId
             },
             { maxTools: maxToolsForNpm(route.npm) }
-          ));
+          ), route));
           if (route.contextWindow && route.contextWindow > 0) {
             const before = params.messages.length;
             const estimatedChars = estimateCodexRequestChars(params);
@@ -4285,9 +4397,31 @@ async function startCodexProxy(routes, options = {}) {
                     log14(`response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
                   }
                 });
+              audit({
+                transport: "http",
+                requestedModel: modelId,
+                dispatch: relayDispatch,
+                phase: "complete",
+                provider: route.providerId ?? "relay",
+                routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+                outcome: "ok",
+                status: 200
+              });
             } catch (err) {
               const msg = formatUpstreamError(err);
               const status = upstreamHttpStatus(err, msg);
+              audit({
+                transport: "http",
+                requestedModel: modelId,
+                dispatch: relayDispatch,
+                phase: "complete",
+                provider: route.providerId ?? "relay",
+                routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+                outcome: "error",
+                status
+              });
               if (debug) log14(`sdk error: ${route.modelId}: ${msg}`);
               if (status === 429) {
                 writeResponsesRateLimitStream(modelId, msg, write);
@@ -4309,9 +4443,31 @@ async function startCodexProxy(routes, options = {}) {
                 });
               }
               sendJson(res, 200, response);
+              audit({
+                transport: "http",
+                requestedModel: modelId,
+                dispatch: relayDispatch,
+                phase: "complete",
+                provider: route.providerId ?? "relay",
+                routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+                outcome: "ok",
+                status: 200
+              });
             } catch (err) {
               const msg = formatUpstreamError(err);
               const status = upstreamHttpStatus(err, msg);
+              audit({
+                transport: "http",
+                requestedModel: modelId,
+                dispatch: relayDispatch,
+                phase: "complete",
+                provider: route.providerId ?? "relay",
+                routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+                outcome: "error",
+                status
+              });
               if (debug) log14(`sdk error: ${route.modelId}: ${msg}`);
               if (status === 429) {
                 sendJson(res, 200, responsesRateLimitBody(modelId, msg));
@@ -4531,6 +4687,7 @@ data: ${JSON.stringify({ error: { message: "Invalid JSON", type: "invalid_reques
             log14(`WS subagent dispatch: requested=${modelId} route=${subagentRoute?.modelId ?? "(none)"}`);
           }
           if (mixedNative && markedSubagent && !subagentRoute) {
+            audit({ transport: "ws", requestedModel: modelId, dispatch: "relay-subagent", phase: "complete", outcome: "error", status: 503 });
             sendWsEvent(`event: error
 data: ${JSON.stringify({ error: {
               message: "Codex marked this request as a Sub-agent, but no configured Codex Sub-agent route is available.",
@@ -4545,6 +4702,7 @@ data: ${JSON.stringify({ error: {
             if (!markedSubagent) {
               const dispatch = classifyCodexDispatch(modelId, routes, mixedNative.nativeModelIds);
               if (dispatch.kind === "unknown") {
+                audit({ transport: "ws", requestedModel: modelId, dispatch: "unknown", phase: "complete", outcome: "error", status: 404 });
                 sendWsEvent(`event: error
 data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "invalid_request_error" } })}
 
@@ -4553,6 +4711,15 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                 return;
               }
               if (dispatch.kind === "native") {
+                audit({
+                  transport: "ws",
+                  requestedModel: modelId,
+                  dispatch: "native",
+                  phase: "dispatch",
+                  provider: "openai-native",
+                  routeModel: modelId,
+                  upstreamModel: modelId
+                });
                 const nativeBody = prepareNativeCodexBody(body);
                 if (debug && nativeBody !== body) {
                   log14(`WS native history normalized: model=${modelId} converted Relay compaction for native verification`);
@@ -4595,6 +4762,19 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                   if (debug && message) {
                     log14(`WS native upstream failed: model=${modelId} opened=${nativeOpened} frames=${nativeFrameCount} message=${message}`);
                   }
+                  if (message && !nativeCompleted) {
+                    audit({
+                      transport: "ws",
+                      requestedModel: modelId,
+                      dispatch: "native",
+                      phase: "complete",
+                      provider: "openai-native",
+                      routeModel: modelId,
+                      upstreamModel: modelId,
+                      outcome: "error",
+                      status: "upstream-failed"
+                    });
+                  }
                   if (message && !nativeCompleted) sendNativeError(message);
                   try {
                     upstream?.close();
@@ -4633,6 +4813,17 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                       if (typeof parsed.type === "string") eventType = parsed.type;
                       if (eventType === "response.completed" || eventType === "response.failed" || eventType === "response.incomplete") {
                         nativeCompleted = true;
+                        audit({
+                          transport: "ws",
+                          requestedModel: modelId,
+                          dispatch: "native",
+                          phase: "complete",
+                          provider: "openai-native",
+                          routeModel: modelId,
+                          upstreamModel: modelId,
+                          outcome: eventType === "response.completed" ? "ok" : "error",
+                          status: eventType
+                        });
                       }
                     } catch {
                     }
@@ -4685,13 +4876,23 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
             }
           }
           const { route, languageModel } = resolved;
+          const relayDispatch = markedSubagent ? "relay-subagent" : "relay";
+          audit({
+            transport: "ws",
+            requestedModel: modelId,
+            dispatch: relayDispatch,
+            phase: "dispatch",
+            provider: route.providerId ?? "relay",
+            routeModel: route.modelId,
+            upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId
+          });
           try {
             const routedBody = await prepareExternalCodexBody(body, {
               relay: nativePayloadRelay,
               mixedNative,
               headers: req.headers
             });
-            let params = applyClaudeCodeOAuthIdentity(route, translateResponsesRequest(
+            let params = applyClaudeCodeOAuthIdentity(route, applyExternalCodexRuntimeIdentity(translateResponsesRequest(
               routedBody,
               route.npm,
               {
@@ -4703,7 +4904,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
                 upstreamModelId: route.upstreamModelId
               },
               { maxTools: maxToolsForNpm(route.npm) }
-            ));
+            ), route));
             if (route.contextWindow && route.contextWindow > 0) {
               const before = params.messages.length;
               const estimatedChars = estimateCodexRequestChars(params);
@@ -4736,9 +4937,31 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
                   log14(`WS response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
                 }
               });
+            audit({
+              transport: "ws",
+              requestedModel: modelId,
+              dispatch: relayDispatch,
+              phase: "complete",
+              provider: route.providerId ?? "relay",
+              routeModel: route.modelId,
+              upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+              outcome: "ok",
+              status: "response.completed"
+            });
           } catch (err) {
             const msg = formatUpstreamError(err);
             const status = upstreamHttpStatus(err, msg);
+            audit({
+              transport: "ws",
+              requestedModel: modelId,
+              dispatch: relayDispatch,
+              phase: "complete",
+              provider: route.providerId ?? "relay",
+              routeModel: route.modelId,
+              upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+              outcome: "error",
+              status
+            });
             if (debug) log14(`WS sdk error: ${route.modelId}: ${msg}`);
             if (status === 429) {
               writeResponsesRateLimitStream(modelId, msg, sendWsEvent);
@@ -4774,44 +4997,44 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
 }
 
 // src/codex/profile.ts
-import { join as join3 } from "path";
+import { join as join4 } from "path";
 
 // src/codex/session.ts
 import {
   copyFileSync,
-  chmodSync,
+  chmodSync as chmodSync2,
   existsSync as existsSync3,
-  mkdirSync,
+  mkdirSync as mkdirSync2,
   readdirSync,
   readFileSync as readFileSync2,
   renameSync,
   rmSync,
   statSync,
   unlinkSync,
-  writeFileSync
+  writeFileSync as writeFileSync2
 } from "fs";
 import { homedir as homedir3 } from "os";
-import { basename, dirname, join as join2 } from "path";
+import { basename, dirname, join as join3 } from "path";
 var CODEX_PROFILE_NAME = "relay-ai-launch";
 var STALE_SESSION_MS = 5 * 60 * 1e3;
 var MAX_BACKUPS = 5;
 function getCodexHome(env = process.env) {
-  return env["CODEX_HOME"] || join2(homedir3(), ".codex");
+  return env["CODEX_HOME"] || join3(homedir3(), ".codex");
 }
 function getCodexProfilePath() {
-  return join2(getCodexHome(), `${CODEX_PROFILE_NAME}.config.toml`);
+  return join3(getCodexHome(), `${CODEX_PROFILE_NAME}.config.toml`);
 }
 function getRelayAiCodexDir(env = process.env) {
-  return join2(getAppHome(env), "codex");
+  return join3(getAppHome(env), "codex");
 }
 function getSessionLockPath(env = process.env) {
-  return join2(getRelayAiCodexDir(env), "session.json");
+  return join3(getRelayAiCodexDir(env), "session.json");
 }
 function getBackupsDir(env = process.env) {
-  return join2(getRelayAiCodexDir(env), "backups");
+  return join3(getRelayAiCodexDir(env), "backups");
 }
 function getCatalogPath(providerId, env = process.env) {
-  return join2(getRelayAiCodexDir(env), `models-${providerId}.json`);
+  return join3(getRelayAiCodexDir(env), `models-${providerId}.json`);
 }
 function ownedOverlayPaths(env = process.env) {
   const paths = [getCodexProfilePath()];
@@ -4819,15 +5042,15 @@ function ownedOverlayPaths(env = process.env) {
   if (existsSync3(codexDir)) {
     for (const name of readdirSync(codexDir)) {
       if (name.startsWith("models-") && name.endsWith(".json")) {
-        paths.push(join2(codexDir, name));
+        paths.push(join3(codexDir, name));
       }
     }
   }
-  const agentsDir = join2(getCodexHome(env), "agents");
+  const agentsDir = join3(getCodexHome(env), "agents");
   if (existsSync3(agentsDir)) {
     for (const name of readdirSync(agentsDir)) {
       if (/^relay-model-[a-z0-9-]+\.toml$/i.test(name)) {
-        paths.push(join2(agentsDir, name));
+        paths.push(join3(agentsDir, name));
       }
     }
   }
@@ -4835,27 +5058,27 @@ function ownedOverlayPaths(env = process.env) {
   return paths;
 }
 function atomicWriteFile(path3, content) {
-  mkdirSync(dirname(path3), { recursive: true });
+  mkdirSync2(dirname(path3), { recursive: true });
   const tmp = `${path3}.tmp.${process.pid}`;
-  writeFileSync(tmp, content, { encoding: "utf8", mode: 384 });
+  writeFileSync2(tmp, content, { encoding: "utf8", mode: 384 });
   renameSync(tmp, path3);
   try {
-    chmodSync(path3, 384);
+    chmodSync2(path3, 384);
   } catch {
   }
 }
 function rotateBackups(filePath, env = process.env) {
   if (!existsSync3(filePath)) return;
   const backupsDir = getBackupsDir(env);
-  mkdirSync(backupsDir, { recursive: true });
+  mkdirSync2(backupsDir, { recursive: true });
   const base = basename(filePath);
   const stamp = Date.now();
-  const backupPath = join2(backupsDir, `${base}.${stamp}.bak`);
+  const backupPath = join3(backupsDir, `${base}.${stamp}.bak`);
   copyFileSync(filePath, backupPath);
-  const backups = readdirSync(backupsDir).filter((n) => n.startsWith(`${base}.`) && n.endsWith(".bak")).map((n) => ({ name: n, mtime: statSync(join2(backupsDir, n)).mtimeMs })).sort((a, b) => b.mtime - a.mtime);
+  const backups = readdirSync(backupsDir).filter((n) => n.startsWith(`${base}.`) && n.endsWith(".bak")).map((n) => ({ name: n, mtime: statSync(join3(backupsDir, n)).mtimeMs })).sort((a, b) => b.mtime - a.mtime);
   for (const old of backups.slice(MAX_BACKUPS)) {
     try {
-      unlinkSync(join2(backupsDir, old.name));
+      unlinkSync(join3(backupsDir, old.name));
     } catch {
     }
   }
@@ -4876,7 +5099,7 @@ function readSessionLock(env = process.env) {
 }
 function writeSessionLock(lock, env = process.env) {
   const path3 = getSessionLockPath(env);
-  mkdirSync(getRelayAiCodexDir(env), { recursive: true });
+  mkdirSync2(getRelayAiCodexDir(env), { recursive: true });
   atomicWriteFile(path3, `${JSON.stringify(lock, null, 2)}
 `);
 }
@@ -4999,10 +5222,10 @@ function getCatalogOutputPath(providerId) {
   return getCatalogPath(providerId);
 }
 function getFavoritesCatalogPath() {
-  return join3(getRelayAiCodexDir(), "models-favorites.json");
+  return join4(getRelayAiCodexDir(), "models-favorites.json");
 }
 function getFavoritesAppCatalogPath() {
-  return join3(getRelayAiCodexDir(), "app-models-favorites.json");
+  return join4(getRelayAiCodexDir(), "app-models-favorites.json");
 }
 function profileName() {
   return CODEX_PROFILE_NAME;
@@ -5013,7 +5236,7 @@ import { execSync as execSync2 } from "child_process";
 import spawn2 from "cross-spawn";
 import { existsSync as existsSync4 } from "fs";
 import { homedir as homedir4 } from "os";
-import { join as join4 } from "path";
+import { join as join5 } from "path";
 var isWindows2 = process.platform === "win32";
 var CODEX_CI_ENV_VARS = [
   "CI",
@@ -5034,11 +5257,11 @@ function stripCodexInheritedEnv(env) {
   return out;
 }
 var CODEX_FALLBACK_PATHS = isWindows2 ? [
-  join4(process.env["APPDATA"] ?? homedir4(), "npm", "codex.cmd"),
-  join4(process.env["APPDATA"] ?? homedir4(), "npm", "codex")
+  join5(process.env["APPDATA"] ?? homedir4(), "npm", "codex.cmd"),
+  join5(process.env["APPDATA"] ?? homedir4(), "npm", "codex")
 ] : [
-  join4(homedir4(), ".local", "bin", "codex"),
-  join4(homedir4(), ".npm", "bin", "codex"),
+  join5(homedir4(), ".local", "bin", "codex"),
+  join5(homedir4(), ".npm", "bin", "codex"),
   "/usr/local/bin/codex",
   "/opt/homebrew/bin/codex"
 ];
@@ -5541,7 +5764,8 @@ async function resolveCodexMixedModels(input) {
     subagents: subagentResult.resolved,
     all,
     providersById: new Map(input.compatible.map((provider) => [provider.id, provider])),
-    dropped: [...visibleResult.droppedFavorites, ...subagentResult.droppedFavorites]
+    dropped: [...visibleResult.droppedFavorites, ...subagentResult.droppedFavorites],
+    capacitySkipped: [...visibleResult.capacitySkippedFavorites, ...subagentResult.capacitySkippedFavorites]
   };
 }
 
@@ -5741,6 +5965,7 @@ async function prepareCodexMixedRelayRoutes(models, trace = false) {
         apiKey: backend.token,
         baseURL: `http://127.0.0.1:${backend.port}`,
         upstreamModelId: proxyRoute.aliasId,
+        auditUpstreamModelId: original.model.upstreamModelId || original.model.id,
         providerId: original.providerId,
         authType: "oauth",
         oauthAccountId: original.oauthAccountId,
@@ -6071,7 +6296,7 @@ async function writeFavoritesLaunchArtifacts(resolved, starting, proxyPort) {
   return { profilePath, catalogPath };
 }
 async function writeMixedLaunchArtifacts(plan, proxyPort) {
-  const catalogPath = join5(getRelayAiCodexDir(), "models-mixed.json");
+  const catalogPath = join6(getRelayAiCodexDir(), "models-mixed.json");
   writeOverlayFile(catalogPath, serializeCatalog(plan.catalog));
   const profilePath = getProfileOutputPath();
   writeOverlayFile(profilePath, buildCodexMixedProfileToml({
@@ -6656,17 +6881,17 @@ import * as p10 from "@clack/prompts";
 
 // src/gemini/launch.ts
 import { spawn as spawn3 } from "child_process";
-import { existsSync as existsSync5, mkdirSync as mkdirSync2, mkdtempSync, rmSync as rmSync2, writeFileSync as writeFileSync2 } from "fs";
+import { existsSync as existsSync5, mkdirSync as mkdirSync3, mkdtempSync, rmSync as rmSync2, writeFileSync as writeFileSync3 } from "fs";
 import { homedir as homedir5, tmpdir } from "os";
-import { join as join6 } from "path";
+import { join as join7 } from "path";
 var isWindows3 = process.platform === "win32";
 var GEMINI_API_KEY_AUTH_TYPE = "gemini-api-key";
 var GEMINI_FALLBACK_PATHS = isWindows3 ? [
-  join6(process.env["APPDATA"] ?? homedir5(), "npm", "gemini.cmd"),
-  join6(process.env["APPDATA"] ?? homedir5(), "npm", "gemini")
+  join7(process.env["APPDATA"] ?? homedir5(), "npm", "gemini.cmd"),
+  join7(process.env["APPDATA"] ?? homedir5(), "npm", "gemini")
 ] : [
-  join6(homedir5(), ".local", "bin", "gemini"),
-  join6(homedir5(), ".npm", "bin", "gemini"),
+  join7(homedir5(), ".local", "bin", "gemini"),
+  join7(homedir5(), ".npm", "bin", "gemini"),
   "/usr/local/bin/gemini",
   "/opt/homebrew/bin/gemini"
 ];
@@ -6687,7 +6912,7 @@ function buildGeminiChildEnv(proxyPort, proxyToken) {
   return env;
 }
 function createGeminiCliHomeOverlay() {
-  const cliHome = mkdtempSync(join6(tmpdir(), "relay-ai-gemini-"));
+  const cliHome = mkdtempSync(join7(tmpdir(), "relay-ai-gemini-"));
   const settings = {
     security: {
       auth: {
@@ -6695,9 +6920,9 @@ function createGeminiCliHomeOverlay() {
       }
     }
   };
-  const geminiDir = join6(cliHome, ".gemini");
-  mkdirSync2(geminiDir);
-  writeFileSync2(join6(geminiDir, "settings.json"), `${JSON.stringify(settings, null, 2)}
+  const geminiDir = join7(cliHome, ".gemini");
+  mkdirSync3(geminiDir);
+  writeFileSync3(join7(geminiDir, "settings.json"), `${JSON.stringify(settings, null, 2)}
 `, {
     encoding: "utf8",
     mode: 384
@@ -9939,15 +10164,15 @@ import { execFileSync, execSync as execSync3 } from "child_process";
 import spawn4 from "cross-spawn";
 import { existsSync as existsSync6 } from "fs";
 import { homedir as homedir6 } from "os";
-import { join as join7 } from "path";
+import { join as join8 } from "path";
 var isWindows4 = process.platform === "win32";
 var FALLBACK_PATHS = isWindows4 ? [
-  join7(process.env["APPDATA"] ?? homedir6(), "npm", "agy.cmd"),
-  join7(process.env["APPDATA"] ?? homedir6(), "npm", "agy"),
-  join7(homedir6(), "AppData", "Roaming", "npm", "agy.cmd")
+  join8(process.env["APPDATA"] ?? homedir6(), "npm", "agy.cmd"),
+  join8(process.env["APPDATA"] ?? homedir6(), "npm", "agy"),
+  join8(homedir6(), "AppData", "Roaming", "npm", "agy.cmd")
 ] : [
-  join7(homedir6(), ".local", "bin", "agy"),
-  join7(homedir6(), ".npm", "bin", "agy"),
+  join8(homedir6(), ".local", "bin", "agy"),
+  join8(homedir6(), ".npm", "bin", "agy"),
   "/usr/local/bin/agy",
   "/opt/homebrew/bin/agy"
 ];
@@ -10025,7 +10250,7 @@ function launchAntigravityCli(env, extraArgs) {
 import { execFileSync as execFileSync2, execSync as execSync4, spawn as spawn5 } from "child_process";
 import { existsSync as existsSync7 } from "fs";
 import { homedir as homedir7 } from "os";
-import { join as join8 } from "path";
+import { join as join9 } from "path";
 
 // src/antigravity/ide-profile.ts
 import fs from "fs";
@@ -10059,8 +10284,8 @@ function prepareIdeProfile(profileDir, gatewayUrl) {
 }
 
 // src/antigravity/launch-ide.ts
-var LINUX_APP_PROFILE_DIR = join8(homedir7(), ".relay-ai", "antigravity", "app-profile");
-var LINUX_IDE_PROFILE_DIR = join8(homedir7(), ".relay-ai", "antigravity", "profile");
+var LINUX_APP_PROFILE_DIR = join9(homedir7(), ".relay-ai", "antigravity", "app-profile");
+var LINUX_IDE_PROFILE_DIR = join9(homedir7(), ".relay-ai", "antigravity", "profile");
 function sleep(ms) {
   return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
@@ -10068,7 +10293,7 @@ function linuxAntigravityBinary() {
   const candidates = [
     "/usr/share/antigravity/antigravity",
     "/opt/antigravity/antigravity",
-    join8(homedir7(), ".local", "share", "antigravity", "antigravity")
+    join9(homedir7(), ".local", "share", "antigravity", "antigravity")
   ];
   for (const candidate of candidates) {
     if (existsSync7(candidate)) return candidate;
@@ -10223,15 +10448,15 @@ function findAntigravityAppBinary() {
   const override = getAppPathOverride("antigravity");
   if (override) return existsSync7(override) ? override : null;
   if (process.platform === "win32") {
-    const localAppData = process.env["LOCALAPPDATA"] ?? join8(homedir7(), "AppData", "Local");
-    const winPath = join8(localAppData, "Programs", "Antigravity", "Antigravity.exe");
+    const localAppData = process.env["LOCALAPPDATA"] ?? join9(homedir7(), "AppData", "Local");
+    const winPath = join9(localAppData, "Programs", "Antigravity", "Antigravity.exe");
     return existsSync7(winPath) ? winPath : null;
   }
   if (process.platform === "linux") return linuxAntigravityBinary();
   if (process.platform !== "darwin") return null;
   const defaultPath = "/Applications/Antigravity.app/Contents/MacOS/Antigravity";
   if (existsSync7(defaultPath)) return defaultPath;
-  const homePath = join8(homedir7(), "Applications", "Antigravity.app", "Contents", "MacOS", "Antigravity");
+  const homePath = join9(homedir7(), "Applications", "Antigravity.app", "Contents", "MacOS", "Antigravity");
   if (existsSync7(homePath)) return homePath;
   return null;
 }
@@ -10239,15 +10464,15 @@ function findAntigravityIdeBinary() {
   const override = getAppPathOverride("antigravity-ide");
   if (override) return existsSync7(override) ? override : null;
   if (process.platform === "win32") {
-    const localAppData = process.env["LOCALAPPDATA"] ?? join8(homedir7(), "AppData", "Local");
-    const winPath = join8(localAppData, "Programs", "Antigravity IDE", "Antigravity IDE.exe");
+    const localAppData = process.env["LOCALAPPDATA"] ?? join9(homedir7(), "AppData", "Local");
+    const winPath = join9(localAppData, "Programs", "Antigravity IDE", "Antigravity IDE.exe");
     return existsSync7(winPath) ? winPath : null;
   }
   if (process.platform === "linux") return linuxAntigravityBinary();
   if (process.platform !== "darwin") return null;
   const defaultPath = "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide";
   if (existsSync7(defaultPath)) return defaultPath;
-  const homePath = join8(homedir7(), "Applications", "Antigravity IDE.app", "Contents", "Resources", "app", "bin", "antigravity-ide");
+  const homePath = join9(homedir7(), "Applications", "Antigravity IDE.app", "Contents", "Resources", "app", "bin", "antigravity-ide");
   if (existsSync7(homePath)) return homePath;
   return null;
 }
@@ -10308,7 +10533,7 @@ function launchAntigravityIde(env, profileDir, gatewayUrl, extraArgs) {
       return;
     }
     prepareIdeProfile(profileDir, gatewayUrl);
-    const relayExtensionsDir = join8(homedir7(), ".relay-ai", "antigravity", "extensions");
+    const relayExtensionsDir = join9(homedir7(), ".relay-ai", "antigravity", "extensions");
     const args = [
       `--user-data-dir=${profileDir}`,
       `--extensions-dir=${relayExtensionsDir}`,
@@ -10338,7 +10563,7 @@ function launchAntigravityIde(env, profileDir, gatewayUrl, extraArgs) {
 
 // src/antigravity.ts
 import { homedir as homedir8 } from "os";
-import { join as join9 } from "path";
+import { join as join10 } from "path";
 var SHUTDOWN_DRAIN_MS = 500;
 var AGY_FAVORITES_PROVIDER_ID = "__relay_agy_favorites__";
 var AGY_FAVORITES_PROVIDER_LABEL = "\u2605 Antigravity CLI Favorites";
@@ -10632,7 +10857,7 @@ async function runAntigravityAppCommand(childArgs, trace = false, boot) {
     trace,
     boot,
     async (env, _routes, gatewayHandle) => {
-      const profileDir = join9(homedir8(), ".relay-ai", "antigravity", "app-profile");
+      const profileDir = join10(homedir8(), ".relay-ai", "antigravity", "app-profile");
       if (isAntigravityAppRunning(profileDir)) {
         const restart = await p11.confirm({
           message: "Restart Antigravity to apply this Relay gateway?",
@@ -10680,7 +10905,7 @@ async function runAntigravityIdeCommand(childArgs, trace = false, boot) {
     trace,
     boot,
     async (env, _routes, gatewayHandle) => {
-      const profileDir = join9(homedir8(), ".relay-ai", "antigravity", "profile");
+      const profileDir = join10(homedir8(), ".relay-ai", "antigravity", "profile");
       if (isAntigravityIdeRunning(profileDir)) {
         const restart = await p11.confirm({
           message: "Restart Antigravity IDE to apply this Relay gateway?",
@@ -10725,7 +10950,7 @@ async function runAntigravityIdeCommand(childArgs, trace = false, boot) {
 // src/codex-app.ts
 import pc10 from "picocolors";
 import * as p12 from "@clack/prompts";
-import { join as join12 } from "path";
+import { join as join13 } from "path";
 
 // src/codex/app-provider-routes.ts
 function codexRouteToProxyRoute(provider, model, apiKey) {
@@ -10814,14 +11039,14 @@ async function buildCodexAppProviderCatalogRoutes(provider, apiKey, selectedMode
 }
 
 // src/codex/app-config.ts
-import { existsSync as existsSync8, readFileSync as readFileSync3, rmSync as rmSync3, writeFileSync as writeFileSync3, mkdirSync as mkdirSync3 } from "fs";
-import { dirname as dirname2, join as join10 } from "path";
+import { existsSync as existsSync8, readFileSync as readFileSync3, rmSync as rmSync3, writeFileSync as writeFileSync4, mkdirSync as mkdirSync4 } from "fs";
+import { dirname as dirname2, join as join11 } from "path";
 import { parse, stringify } from "smol-toml";
 function getCodexConfigPath() {
-  return join10(getCodexHome(), "config.toml");
+  return join11(getCodexHome(), "config.toml");
 }
 function getCodexAppSidecarProfilePath() {
-  return join10(getCodexHome(), `${CODEX_APP_PROVIDER_ID}.config.toml`);
+  return join11(getCodexHome(), `${CODEX_APP_PROVIDER_ID}.config.toml`);
 }
 function asRecord(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
@@ -10996,8 +11221,13 @@ function applyAppConfigPatch(spec, configPath = getCodexConfigPath()) {
   const text5 = `${stringify(merged)}
 `;
   validateAppConfigText(text5, spec);
-  mkdirSync3(dirname2(configPath), { recursive: true });
-  writeFileSync3(configPath, text5, "utf8");
+  mkdirSync4(dirname2(configPath), { recursive: true });
+  atomicWriteFile(configPath, text5);
+  const written = readCodexConfigText(configPath);
+  if (written !== text5) {
+    throw new Error(`Codex config readback mismatch at ${configPath}`);
+  }
+  validateAppConfigText(written, spec);
   return text5;
 }
 function applyRestoreKey(config, key, had, value) {
@@ -11053,7 +11283,7 @@ function restoreConfigFromState(state, configPath = getCodexConfigPath()) {
     rmSync3(configPath, { force: true });
     return true;
   }
-  writeFileSync3(configPath, `${stringify(config)}
+  writeFileSync4(configPath, `${stringify(config)}
 `, "utf8");
   return true;
 }
@@ -11064,31 +11294,69 @@ function previewAppConfigToml(spec) {
   return text5;
 }
 
+// src/codex/app-readiness.ts
+import { readFileSync as readFileSync4 } from "fs";
+function proxyRoot(spec) {
+  const base = spec.proxyBaseUrl ?? `http://127.0.0.1:${spec.proxyPort}/v1`;
+  if (!base.endsWith("/v1")) throw new Error("Codex App proxy base URL must end in /v1");
+  return base.slice(0, -3);
+}
+async function checkedJson(url, fetchImpl) {
+  const response = await fetchImpl(url);
+  if (!response.ok) throw new Error(`Relay readiness check failed: GET ${url} returned HTTP ${response.status}`);
+  return response.json();
+}
+async function verifyCodexAppReadiness(spec, options = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const root = proxyRoot(spec);
+  const health = await checkedJson(`${root}/health`, fetchImpl);
+  if (health.ok !== true) throw new Error("Relay proxy health check did not report ready");
+  const catalog = JSON.parse(readFileSync4(spec.catalogPath, "utf8"));
+  if (!Array.isArray(catalog.models) || catalog.models.length === 0) {
+    throw new Error("Relay Codex model catalog is empty or invalid");
+  }
+  const catalogIds = catalog.models.map((model) => model?.slug).filter((id) => typeof id === "string" && id.length > 0);
+  if (catalogIds.length !== catalog.models.length) throw new Error("Relay Codex model catalog contains an invalid model slug");
+  if (!catalogIds.includes(spec.route.modelId)) {
+    throw new Error(`Relay Codex model catalog is missing selected model ${spec.route.modelId}`);
+  }
+  const advertised = await checkedJson(`${root}/v1/models`, fetchImpl);
+  const advertisedIds = new Set((advertised.data ?? []).map((model) => model.id).filter((id) => typeof id === "string"));
+  for (const id of catalogIds) {
+    if (!advertisedIds.has(id)) throw new Error(`Relay proxy does not advertise catalog model ${id}`);
+  }
+  validateAppConfigText(readCodexConfigText(options.configPath), spec);
+}
+
 // src/codex/app-session.ts
 import {
   copyFileSync as copyFileSync2,
   existsSync as existsSync9,
-  mkdirSync as mkdirSync4,
+  mkdirSync as mkdirSync5,
   readdirSync as readdirSync2,
-  readFileSync as readFileSync4,
+  readFileSync as readFileSync5,
   rmSync as rmSync4,
   statSync as statSync2
 } from "fs";
-import { basename as basename2, join as join11 } from "path";
+import { basename as basename2, join as join12 } from "path";
+import { createHash as createHash3 } from "crypto";
 function getAppSessionLockPath(env = process.env) {
-  return join11(getRelayAiCodexDir(env), "session-app.json");
+  return join12(getRelayAiCodexDir(env), "session-app.json");
 }
 function getAppRestoreStatePath(env = process.env) {
-  return join11(getRelayAiCodexDir(env), "app-restore-state.json");
+  return join12(getRelayAiCodexDir(env), "app-restore-state.json");
 }
 function getAppCatalogPath(providerId, env = process.env) {
-  return join11(getRelayAiCodexDir(env), `app-models-${providerId}.json`);
+  return join12(getRelayAiCodexDir(env), `app-models-${providerId}.json`);
+}
+function fileSha256(path3) {
+  return createHash3("sha256").update(readFileSync5(path3)).digest("hex");
 }
 function readAppSessionLock(env = process.env) {
   const path3 = getAppSessionLockPath(env);
   if (!existsSync9(path3)) return null;
   try {
-    const parsed = JSON.parse(readFileSync4(path3, "utf8"));
+    const parsed = JSON.parse(readFileSync5(path3, "utf8"));
     if (typeof parsed.pid === "number" && typeof parsed.startedAt === "string") return parsed;
   } catch {
   }
@@ -11106,7 +11374,7 @@ function readAppRestoreState(env = process.env) {
   const path3 = getAppRestoreStatePath(env);
   if (!existsSync9(path3)) return null;
   try {
-    return JSON.parse(readFileSync4(path3, "utf8"));
+    return JSON.parse(readFileSync5(path3, "utf8"));
   } catch {
     return null;
   }
@@ -11125,9 +11393,9 @@ function backupConfigToml(env = process.env) {
   if (!existsSync9(configPath)) return void 0;
   rotateBackups(configPath, env);
   const backupsDir = getBackupsDir(env);
-  mkdirSync4(backupsDir, { recursive: true });
+  mkdirSync5(backupsDir, { recursive: true });
   const base = basename2(configPath);
-  const backupPath = join11(backupsDir, `${base}.${Date.now()}.bak`);
+  const backupPath = join12(backupsDir, `${base}.${Date.now()}.bak`);
   copyFileSync2(configPath, backupPath);
   return backupPath;
 }
@@ -11144,7 +11412,7 @@ function saveAppRestoreStateBeforePatch(env = process.env) {
 function ownedAppCatalogPaths(env = process.env) {
   const codexDir = getRelayAiCodexDir(env);
   if (!existsSync9(codexDir)) return [];
-  return readdirSync2(codexDir).filter((n) => n.startsWith("app-models-") && n.endsWith(".json")).map((n) => join11(codexDir, n));
+  return readdirSync2(codexDir).filter((n) => n.startsWith("app-models-") && n.endsWith(".json")).map((n) => join12(codexDir, n));
 }
 function removeAppCatalogs(env = process.env) {
   const removed = [];
@@ -11162,7 +11430,7 @@ function newestConfigBackup(env = process.env) {
   if (!existsSync9(backupDir)) return null;
   const configBase = basename2(getCodexConfigPath());
   const candidates = readdirSync2(backupDir).filter((name) => name.startsWith(`${configBase}.`) && name.endsWith(".bak")).map((name) => {
-    const path3 = join11(backupDir, name);
+    const path3 = join12(backupDir, name);
     try {
       return { path: path3, mtimeMs: statSync2(path3).mtimeMs };
     } catch {
@@ -11188,7 +11456,12 @@ function restoreCodexAppOverlay(env = process.env) {
     clearAppSessionLock(env);
     return { restored: false, message: "Nothing to restore." };
   }
-  if (restoreState) {
+  const exactBackupIsSafe = Boolean(
+    managed && lock?.backupPath && existsSync9(lock.backupPath) && lock.patchedConfigSha256 && lock.originalConfigSha256 && fileSha256(getCodexConfigPath()) === lock.patchedConfigSha256 && fileSha256(lock.backupPath) === lock.originalConfigSha256
+  );
+  if (exactBackupIsSafe) {
+    copyFileSync2(lock.backupPath, getCodexConfigPath());
+  } else if (restoreState) {
     restoreConfigFromState(restoreState);
   } else if (lock?.backupPath && existsSync9(lock.backupPath)) {
     copyFileSync2(lock.backupPath, getCodexConfigPath());
@@ -11264,11 +11537,14 @@ function codexProxyRouteToCodexRoute(route, fallbackProviderId) {
     refreshToken: route.refreshToken
   };
 }
-async function waitForShutdownWithConfirm(assumeYes = false) {
+function codexAppUsesExplicitSelection(configOnly, launchProvider, launchModel) {
+  void configOnly;
+  return Boolean(launchProvider && launchModel);
+}
+async function waitForShutdownWithConfirm() {
   while (true) {
     const signal = await waitForShutdown2();
-    if (signal !== "sigint") break;
-    if (assumeYes) break;
+    if (signal !== "sigint") return signal;
     console.log("");
     const choice = await p12.select({
       message: "Close ChatGPT Desktop and restore your Codex config?",
@@ -11277,16 +11553,14 @@ async function waitForShutdownWithConfirm(assumeYes = false) {
         { value: "no", label: "No, keep session running" }
       ]
     });
-    if (p12.isCancel(choice) || choice === "yes") break;
+    if (p12.isCancel(choice) || choice === "yes") return signal;
   }
 }
-async function maybeCloseRunningCodexApp(assumeYes = false) {
+function unattendedShutdownClosesApp(assumeYes, signal) {
+  return assumeYes && signal !== "sigint";
+}
+async function maybeCloseRunningCodexApp() {
   if (!isCodexAppRunning()) return;
-  if (assumeYes) {
-    p12.log.step("Stopping ChatGPT Desktop...");
-    quitCodexAppGracefully();
-    return;
-  }
   const shouldClose = await p12.confirm({ message: "ChatGPT Desktop is still running. Close it?" });
   if (shouldClose && !p12.isCancel(shouldClose)) {
     p12.log.step("Stopping ChatGPT Desktop...");
@@ -11310,7 +11584,7 @@ ${pc10.bold("Options:")}
   --vertex     Use Claude models through Google Vertex AI
   --with-native Load native Codex models beside Relay models for this launch
   --relay-only Keep the current Relay-only launch behavior
-  --yes, -y     Run a fully specified launch unattended (no launch/stop prompts)
+  --yes, -y     Approve a fully specified launch/restart without prompting
   --restore    Restore Codex config after an interrupted app session
   --config     Preview the generated Codex app configuration without launching
   --trace      Write proxy debug logs to ~/.relay-ai/logs/ and show errors on exit
@@ -11446,8 +11720,10 @@ async function runCodexAppVertexLaunch(configOnly, trace = false) {
       catalogPath
     };
     saveAppRestoreStateBeforePatch();
+    sessionActive = true;
     const backupPath = backupConfigToml();
     applyAppConfigPatch(spec);
+    await verifyCodexAppReadiness(spec);
     writeAppSessionLock({
       pid: process.pid,
       startedAt: (/* @__PURE__ */ new Date()).toISOString(),
@@ -11455,9 +11731,10 @@ async function runCodexAppVertexLaunch(configOnly, trace = false) {
       catalogPaths: [catalogPath],
       restoreStatePath: getAppRestoreStatePath(),
       backupPath,
-      proxyPort
+      proxyPort,
+      patchedConfigSha256: fileSha256(getCodexConfigPath()),
+      ...backupPath ? { originalConfigSha256: fileSha256(backupPath) } : {}
     });
-    sessionActive = true;
     p12.log.info(`Vertex AI \xB7 ${selectedEntry.display_name} \u2014 project: ${config.project} / location: ${config.location}`);
     logProxy(proxyPort);
     logActiveModel(selectedEntry.display_name, selectedEntry.id);
@@ -11466,6 +11743,7 @@ async function runCodexAppVertexLaunch(configOnly, trace = false) {
     } catch (err) {
       p12.log.warn(String(err instanceof Error ? err.message : err));
       p12.log.info(codexAppInstallHint());
+      throw err;
     }
     printCodexAppSessionPanel({
       modelLabel: selectedEntry.display_name,
@@ -11576,7 +11854,7 @@ async function runCodexAppCommand(args, opts = {}) {
     compatible.find((lp) => lp.id === prefs.lastCodexProvider) ?? compatible[0]
   );
   let selectedModel = activeProvider.models.find((m) => m.id === prefs.lastCodexModel) ?? activeProvider.models[0];
-  if (!configOnly && opts.launchProvider && opts.launchModel) {
+  if (codexAppUsesExplicitSelection(configOnly, opts.launchProvider, opts.launchModel)) {
     const bootSelection = resolveBootSelection(
       compatible,
       opts.launchProvider,
@@ -11655,6 +11933,11 @@ async function runCodexAppCommand(args, opts = {}) {
         generalFavorites: favorites,
         subagentFavorites: prefs.codexSubagentModels ?? []
       });
+      if (mixedModels.capacitySkipped.length > 0) {
+        p12.log.warn(
+          `Skipped ${mixedModels.capacitySkipped.length} favorite(s) because the mixed catalog is full: ` + mixedModels.capacitySkipped.map((f) => `${f.providerId}:${f.modelId}`).join(", ")
+        );
+      }
       assertConfiguredCodexSubagentsResolved(prefs.codexSubagentModels ?? [], mixedModels);
       const multiAgentV2Supported = mixedModels.subagents.length === 0 || supportsMultiAgentV2(embeddedBinary);
       if (!multiAgentV2Supported) {
@@ -11694,7 +11977,7 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
   let proxyHandle = null;
   let sessionActive = false;
   try {
-    const catalogPath = mixedPlan ? join12(getRelayAiCodexDir(), "app-models-mixed.json") : favoritesActive && resolvedFavorites.length > 0 ? getFavoritesAppCatalogPath() : getAppCatalogPath(route.providerId);
+    const catalogPath = mixedPlan ? join13(getRelayAiCodexDir(), "app-models-mixed.json") : favoritesActive && resolvedFavorites.length > 0 ? getFavoritesAppCatalogPath() : getAppCatalogPath(route.providerId);
     const activeRoute = mixedPlan ? {
       tier: "proxy",
       modelId: mixedPlan.selectedSlug,
@@ -11757,10 +12040,12 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
       return 0;
     }
     let proxyPort;
+    const routeAuditPath = mixedPlan ? prepareCodexRouteAuditLog() : void 0;
     if (mixedPlan) {
       proxyHandle = await startCodexProxy(mixedPlan.relayRoutes, {
         requireAuth: false,
         debug: trace,
+        routeAuditPath,
         mixedNative: {
           nativeModelIds: mixedPlan.nativeModelIds,
           subagentRouteModelId: mixedPlan.subagentRouteModelId,
@@ -11769,6 +12054,7 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
         }
       });
       proxyPort = proxyHandle.port;
+      p12.log.info(`Route audit (metadata only): ${routeAuditPath}`);
     } else if (favoritesActive && resolvedFavorites.length > 0) {
       const needsBackend = (r) => {
         const m = r.model;
@@ -11828,8 +12114,10 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
       ...mixedPlan ? { proxyBaseUrl: `${mixedProxyBaseUrl(proxyPort, mixedPlan.capability)}/v1` } : {}
     };
     saveAppRestoreStateBeforePatch();
+    sessionActive = true;
     const backupPath = backupConfigToml();
     applyAppConfigPatch(spec);
+    await verifyCodexAppReadiness(spec);
     writeAppSessionLock({
       pid: process.pid,
       startedAt: (/* @__PURE__ */ new Date()).toISOString(),
@@ -11837,9 +12125,10 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
       catalogPaths: [catalogPath],
       restoreStatePath: getAppRestoreStatePath(),
       backupPath,
-      proxyPort
+      proxyPort,
+      patchedConfigSha256: fileSha256(getCodexConfigPath()),
+      ...backupPath ? { originalConfigSha256: fileSha256(backupPath) } : {}
     });
-    sessionActive = true;
     const prevRecent = prefs.recentModelsByProvider?.[activeProvider.id] ?? [];
     const updatedRecent = [selectedModel.id, ...prevRecent.filter((id) => id !== selectedModel.id)].slice(0, 3);
     savePreferences({
@@ -11854,6 +12143,7 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
     } catch (err) {
       p12.log.warn(String(err instanceof Error ? err.message : err));
       p12.log.info(codexAppInstallHint());
+      throw err;
     }
     printCodexAppSessionPanel({
       modelLabel,
@@ -11862,14 +12152,21 @@ Mixed Codex App mode is unavailable: ${err instanceof Error ? err.message : err}
       restoreCommand: "relay-ai codex-app --restore"
     });
     codexAppOutro(modelLabel);
-    await waitForShutdownWithConfirm(opts.assumeYes);
+    const shutdownSignal = await waitForShutdownWithConfirm();
     if (trace) printTraceLog(debugLogPath);
     console.log("");
     if (sessionActive) {
       restoreCodexAppOverlay();
       sessionActive = false;
     }
-    await maybeCloseRunningCodexApp(opts.assumeYes);
+    if (unattendedShutdownClosesApp(Boolean(opts.assumeYes), shutdownSignal)) {
+      if (isCodexAppRunning()) {
+        p12.log.step("Stopping ChatGPT Desktop after unattended Relay shutdown...");
+        quitCodexAppGracefully();
+      }
+    } else {
+      await maybeCloseRunningCodexApp();
+    }
     return 0;
   } finally {
     proxyHandle?.close();
@@ -11888,38 +12185,38 @@ import pc11 from "picocolors";
 import * as p13 from "@clack/prompts";
 
 // src/claude-desktop/app-config.ts
-import { existsSync as existsSync10, readFileSync as readFileSync5, writeFileSync as writeFileSync4, mkdirSync as mkdirSync5 } from "fs";
+import { existsSync as existsSync10, readFileSync as readFileSync6, writeFileSync as writeFileSync5, mkdirSync as mkdirSync6 } from "fs";
 import { homedir as homedir9 } from "os";
-import { join as join13, dirname as dirname3 } from "path";
+import { join as join14, dirname as dirname3 } from "path";
 import { randomUUID as randomUUID3 } from "crypto";
 function getClaudeDesktopHome() {
   if (process.platform === "win32") {
-    return join13(process.env.LOCALAPPDATA || join13(homedir9(), "AppData", "Local"), "Claude-3p");
+    return join14(process.env.LOCALAPPDATA || join14(homedir9(), "AppData", "Local"), "Claude-3p");
   }
   if (process.platform === "linux") {
-    return join13(process.env.XDG_CONFIG_HOME || join13(homedir9(), ".config"), "Claude-3p");
+    return join14(process.env.XDG_CONFIG_HOME || join14(homedir9(), ".config"), "Claude-3p");
   }
-  return join13(homedir9(), "Library", "Application Support", "Claude-3p");
+  return join14(homedir9(), "Library", "Application Support", "Claude-3p");
 }
 function getConfigLibraryPath() {
-  return join13(getClaudeDesktopHome(), "configLibrary");
+  return join14(getClaudeDesktopHome(), "configLibrary");
 }
 function getMetaJsonPath() {
-  return join13(getConfigLibraryPath(), "_meta.json");
+  return join14(getConfigLibraryPath(), "_meta.json");
 }
 function readMetaJson() {
   const metaPath = getMetaJsonPath();
   if (!existsSync10(metaPath)) return null;
   try {
-    return JSON.parse(readFileSync5(metaPath, "utf8"));
+    return JSON.parse(readFileSync6(metaPath, "utf8"));
   } catch {
     return null;
   }
 }
 function writeMetaJson(meta) {
   const metaPath = getMetaJsonPath();
-  mkdirSync5(dirname3(metaPath), { recursive: true });
-  writeFileSync4(metaPath, `${JSON.stringify(meta, null, 2)}
+  mkdirSync6(dirname3(metaPath), { recursive: true });
+  writeFileSync5(metaPath, `${JSON.stringify(meta, null, 2)}
 `, "utf8");
 }
 function buildRelayAiConfig(proxyPort) {
@@ -11933,10 +12230,10 @@ function buildRelayAiConfig(proxyPort) {
 }
 function writeRelayAiConfig(proxyPort) {
   const uuid = randomUUID3();
-  const configPath = join13(getConfigLibraryPath(), `${uuid}.json`);
+  const configPath = join14(getConfigLibraryPath(), `${uuid}.json`);
   const config = buildRelayAiConfig(proxyPort);
-  mkdirSync5(dirname3(configPath), { recursive: true });
-  writeFileSync4(configPath, `${JSON.stringify(config, null, 2)}
+  mkdirSync6(dirname3(configPath), { recursive: true });
+  writeFileSync5(configPath, `${JSON.stringify(config, null, 2)}
 `, "utf8");
   const meta = readMetaJson() || { appliedId: "", entries: [] };
   meta.appliedId = uuid;
@@ -12091,22 +12388,22 @@ async function buildClaudeAppServerCatalog(entries, providersById, trace) {
 import {
   copyFileSync as copyFileSync3,
   existsSync as existsSync11,
-  mkdirSync as mkdirSync6,
-  readFileSync as readFileSync6,
+  mkdirSync as mkdirSync7,
+  readFileSync as readFileSync7,
   renameSync as renameSync2,
   rmSync as rmSync5,
   unlinkSync as unlinkSync2,
-  writeFileSync as writeFileSync5
+  writeFileSync as writeFileSync6
 } from "fs";
-import { dirname as dirname4, join as join14 } from "path";
+import { dirname as dirname4, join as join15 } from "path";
 function getSessionLockPath2() {
-  return join14(getClaudeDesktopHome(), ".relay-ai.lock");
+  return join15(getClaudeDesktopHome(), ".relay-ai.lock");
 }
 function inspectSessionLock() {
   const path3 = getSessionLockPath2();
   if (!existsSync11(path3)) return { status: "missing" };
   try {
-    const parsed = JSON.parse(readFileSync6(path3, "utf8"));
+    const parsed = JSON.parse(readFileSync7(path3, "utf8"));
     if (typeof parsed.pid === "number" && typeof parsed.startedAt === "string" && typeof parsed.uuid === "string" && typeof parsed.proxyPort === "number") {
       return { status: "valid", lock: parsed };
     }
@@ -12117,9 +12414,9 @@ function inspectSessionLock() {
 function writeSessionLock2(lock) {
   const path3 = getSessionLockPath2();
   const tempPath = `${path3}.tmp.${process.pid}`;
-  mkdirSync6(dirname4(path3), { recursive: true });
+  mkdirSync7(dirname4(path3), { recursive: true });
   try {
-    writeFileSync5(tempPath, `${JSON.stringify(lock, null, 2)}
+    writeFileSync6(tempPath, `${JSON.stringify(lock, null, 2)}
 `, "utf8");
     renameSync2(tempPath, path3);
   } finally {
@@ -12154,7 +12451,7 @@ function restoreMetaJson() {
   }
 }
 function removeRelayAiConfig(uuid) {
-  const configPath = join14(getConfigLibraryPath(), `${uuid}.json`);
+  const configPath = join15(getConfigLibraryPath(), `${uuid}.json`);
   if (existsSync11(configPath)) {
     try {
       rmSync5(configPath, { force: true });
@@ -12472,17 +12769,17 @@ ${pc11.bold("Claude Desktop 3P Mode Active")}`);
 }
 
 // src/ai-doc.ts
-import { existsSync as existsSync12, mkdirSync as mkdirSync7, readFileSync as readFileSync7, writeFileSync as writeFileSync6 } from "fs";
+import { existsSync as existsSync12, mkdirSync as mkdirSync8, readFileSync as readFileSync8, writeFileSync as writeFileSync7 } from "fs";
 import { homedir as homedir10 } from "os";
-import { join as join15 } from "path";
+import { join as join16 } from "path";
 var SKILL_DIR_NAME = "relay-ai-cli";
 var SKILL_INSTALL_DIRS = [
-  join15(getAppHome(), "skills"),
-  join15(homedir10(), ".claude", "skills"),
-  join15(homedir10(), ".agents", "skills"),
-  join15(homedir10(), ".codex", "skills"),
-  join15(homedir10(), ".cursor", "skills"),
-  join15(homedir10(), ".cursor", "skills-cursor")
+  join16(getAppHome(), "skills"),
+  join16(homedir10(), ".claude", "skills"),
+  join16(homedir10(), ".agents", "skills"),
+  join16(homedir10(), ".codex", "skills"),
+  join16(homedir10(), ".cursor", "skills"),
+  join16(homedir10(), ".cursor", "skills-cursor")
 ];
 function parseSkillVersion(content) {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -12496,10 +12793,10 @@ function parseSkillVersion(content) {
   return null;
 }
 function readInstalledSkillVersion(skillDir) {
-  const skillPath = join15(skillDir, "SKILL.md");
+  const skillPath = join16(skillDir, "SKILL.md");
   if (!existsSync12(skillPath)) return null;
   try {
-    const head = readFileSync7(skillPath, "utf-8").slice(0, 1024);
+    const head = readFileSync8(skillPath, "utf-8").slice(0, 1024);
     return parseSkillVersion(head.includes("---", 4) ? head : `${head}
 ---
 `);
@@ -12509,8 +12806,8 @@ function readInstalledSkillVersion(skillDir) {
 }
 function skillInstallTargets() {
   return SKILL_INSTALL_DIRS.map((dir) => {
-    const skillDir = join15(dir, SKILL_DIR_NAME);
-    return { skillDir, skillPath: join15(skillDir, "SKILL.md") };
+    const skillDir = join16(dir, SKILL_DIR_NAME);
+    return { skillDir, skillPath: join16(skillDir, "SKILL.md") };
   });
 }
 function formatProviderModels(provider) {
@@ -13014,8 +13311,8 @@ function installAiDoc(opts = {}) {
         result.skipped.push(skillPath);
         continue;
       }
-      mkdirSync7(skillDir, { recursive: true });
-      writeFileSync6(skillPath, doc, "utf-8");
+      mkdirSync8(skillDir, { recursive: true });
+      writeFileSync7(skillPath, doc, "utf-8");
       if (previous) {
         result.updated.push({ path: skillPath, fromVersion: previous });
       } else {
@@ -13175,16 +13472,16 @@ function buildHttpProxyChildEnv(baseEnv, proxyUrl, caCertPath) {
 // src/http-proxy/ca.ts
 import { randomBytes as randomBytes2, randomUUID as randomUUID4 } from "crypto";
 import {
-  chmodSync as chmodSync2,
+  chmodSync as chmodSync3,
   existsSync as existsSync13,
-  mkdirSync as mkdirSync9,
-  readFileSync as readFileSync8,
+  mkdirSync as mkdirSync10,
+  readFileSync as readFileSync9,
   readdirSync as readdirSync3,
   rmSync as rmSync6,
   statSync as statSync3,
-  writeFileSync as writeFileSync8
+  writeFileSync as writeFileSync9
 } from "fs";
-import { dirname as dirname6, join as join17, resolve } from "path";
+import { dirname as dirname6, join as join18, resolve } from "path";
 import forge from "node-forge";
 var SESSION_ROOT = "http-proxy-sessions";
 var OWNER_FILE = "owner.pid";
@@ -13204,22 +13501,22 @@ function processIsRunning(pid) {
   }
 }
 function cleanupStaleHttpProxySessions(appHome = getAppHome()) {
-  const root = join17(appHome, SESSION_ROOT);
+  const root = join18(appHome, SESSION_ROOT);
   if (!existsSync13(root)) return;
   const now = Date.now();
   for (const name of readdirSync3(root)) {
-    const sessionDir = join17(root, name);
+    const sessionDir = join18(root, name);
     try {
       const stat = statSync3(sessionDir);
       if (!stat.isDirectory()) continue;
-      const ownerPath = join17(sessionDir, OWNER_FILE);
+      const ownerPath = join18(sessionDir, OWNER_FILE);
       if (!existsSync13(ownerPath)) {
         if (now - stat.mtimeMs > MID_CREATION_GRACE_MS) {
           rmSync6(sessionDir, { recursive: true, force: true });
         }
         continue;
       }
-      const pid = Number(readFileSync8(ownerPath, "utf8").trim());
+      const pid = Number(readFileSync9(ownerPath, "utf8").trim());
       if (!Number.isSafeInteger(pid) || pid <= 0) {
         const ownerStat = statSync3(ownerPath);
         const newestMtimeMs = Math.max(stat.mtimeMs, ownerStat.mtimeMs);
@@ -13235,13 +13532,13 @@ function cleanupStaleHttpProxySessions(appHome = getAppHome()) {
 }
 function createHttpProxyCertificates(appHome = getAppHome()) {
   cleanupStaleHttpProxySessions(appHome);
-  const root = join17(appHome, SESSION_ROOT);
-  mkdirSync9(root, { recursive: true, mode: 448 });
-  chmodSync2(root, 448);
-  const sessionDir = join17(root, randomUUID4());
-  mkdirSync9(sessionDir, { mode: 448 });
-  chmodSync2(sessionDir, 448);
-  writeFileSync8(join17(sessionDir, OWNER_FILE), `${process.pid}
+  const root = join18(appHome, SESSION_ROOT);
+  mkdirSync10(root, { recursive: true, mode: 448 });
+  chmodSync3(root, 448);
+  const sessionDir = join18(root, randomUUID4());
+  mkdirSync10(sessionDir, { mode: 448 });
+  chmodSync3(sessionDir, 448);
+  writeFileSync9(join18(sessionDir, OWNER_FILE), `${process.pid}
 `, { mode: 384 });
   try {
     const caKeys = forge.pki.rsa.generateKeyPair(2048);
@@ -13276,9 +13573,9 @@ function createHttpProxyCertificates(appHome = getAppHome()) {
     ]);
     server.sign(caKeys.privateKey, forge.md.sha256.create());
     const caCert = forge.pki.certificateToPem(ca);
-    const caCertPath = join17(sessionDir, "relay-ai-ca.pem");
-    writeFileSync8(caCertPath, caCert, { encoding: "utf8", mode: 384 });
-    chmodSync2(caCertPath, 384);
+    const caCertPath = join18(sessionDir, "relay-ai-ca.pem");
+    writeFileSync9(caCertPath, caCert, { encoding: "utf8", mode: 384 });
+    chmodSync3(caCertPath, 384);
     let cleaned = false;
     const cleanupOnExit = () => {
       if (cleaned) return;
@@ -13319,18 +13616,18 @@ function createHttpProxyCaBundle(relayCaCertPath, additionalCaCertPath) {
   if (resolve(additionalCaCertPath) === resolve(relayCaCertPath)) {
     return relayCaCertPath;
   }
-  const relayCa = readFileSync8(relayCaCertPath, "utf8").trimEnd();
-  const additionalCa = readFileSync8(additionalCaCertPath, "utf8").trim();
+  const relayCa = readFileSync9(relayCaCertPath, "utf8").trimEnd();
+  const additionalCa = readFileSync9(additionalCaCertPath, "utf8").trim();
   if (!additionalCa) return relayCaCertPath;
-  const combinedPath = join17(dirname6(relayCaCertPath), "combined-ca.pem");
-  writeFileSync8(
+  const combinedPath = join18(dirname6(relayCaCertPath), "combined-ca.pem");
+  writeFileSync9(
     combinedPath,
     `${relayCa}
 ${additionalCa}
 `,
     { encoding: "utf8", mode: 384 }
   );
-  chmodSync2(combinedPath, 384);
+  chmodSync3(combinedPath, 384);
   return combinedPath;
 }
 
@@ -15345,7 +15642,7 @@ Options:
   --trace    Write debug logs under ~/.relay-ai/logs/`);
       return 0;
     }
-    const { runUiCommand } = await import("./ui-command-Q6LBKVM3.js");
+    const { runUiCommand } = await import("./ui-command-MKOUZ3AI.js");
     return runUiCommand({ trace: parsed.trace, serverMode: parsed.uiServerMode });
   }
   if (parsed.command === "models") {

--- a/dist/ui-command-MKOUZ3AI.js
+++ b/dist/ui-command-MKOUZ3AI.js
@@ -85,7 +85,7 @@ import {
   updateCustomEndpointProvider,
   validateCustomEndpointUrl,
   writeSecureLogLine
-} from "./chunk-SCW2TYSG.js";
+} from "./chunk-OIYXDMMG.js";
 import {
   __toCommonJS,
   init_provider_templates,
@@ -1810,4 +1810,4 @@ export {
   resolveUiShutdownDecision,
   runUiCommand
 };
-//# sourceMappingURL=ui-command-Q6LBKVM3.js.map
+//# sourceMappingURL=ui-command-MKOUZ3AI.js.map

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -152,16 +152,18 @@ For unattended startup, specify every launch choice and add `--yes`:
 relay-ai codex-app --provider antigravity --model gemini-3.1-pro-high --with-native --yes
 ```
 
-`--yes` bypasses the launch, restart, and shutdown confirmations. To prevent an
-unattended launch from relying on saved or default choices, it requires
-`--provider`, `--model`, and either `--with-native` or `--relay-only`.
-
-Under `--yes`, `SIGINT` stops the session the same way `SIGTERM` already does:
-the Codex config is restored and the app is closed without asking. Without
-`--yes`, `SIGINT` still asks before closing, so an interactive session can keep
-the app running.
+`--yes` bypasses the launch and restart confirmations. To prevent an unattended
+launch from relying on saved or default choices, it requires `--provider`,
+`--model`, and either `--with-native` or `--relay-only`.
 
 Pick provider → pick model → Codex **app** opens. **Keep the relay-ai terminal open** until you’re done (the app always uses the foreground proxy). Press **Ctrl+C** to stop the proxy and restore your previous Codex config.
+
+Relay does not launch ChatGPT until the provider catalog resolves, the proxy is
+listening, its health and model catalog pass validation, and the temporary
+`config.toml` patch has been written and read back successfully. On macOS it
+targets the `com.openai.codex` bundle directly and verifies that the prior main
+process actually exited; closing only the visible Electron window is not
+treated as a restart.
 
 **Platforms:** macOS, Windows, and Linux. On Linux, Relay detects the packaged ChatGPT app at `/usr/bin/chatgpt` or `/usr/lib/chatgpt/ChatGPT` and its embedded Codex runtime at `/usr/lib/chatgpt/resources/codex`.
 
@@ -180,7 +182,10 @@ Linux desktop launches also restart an existing ChatGPT process when necessary s
 | `--config` | **Preview only** — print TOML that would be written; no disk writes, no app, no proxy |
 | `--help` | Help text |
 
-**`--config` note:** Skips the picker. Uses your last Codex provider/model from prefs (or the first compatible provider). The proxy port shown (`54321`) is a **placeholder**; a real launch uses a random port.
+**`--config` note:** Skips the picker. When `--provider` and `--model` are
+supplied, the preview uses that exact selection; otherwise it uses your last
+Codex provider/model from prefs (or the first compatible provider). The proxy
+port shown (`54321`) is a **placeholder**; a real launch uses a random port.
 
 ### Files relay-ai owns (App)
 
@@ -191,6 +196,7 @@ Linux desktop launches also restart an existing ChatGPT process when necessary s
 | `~/.relay-ai/codex/session-app.json` | App session lock |
 | `~/.relay-ai/codex/app-restore-state.json` | Snapshot of your pre-session root keys (for surgical restore) |
 | `~/.relay-ai/codex/backups/config.toml.*.bak` | Rotating file backups before each patch |
+| `~/.relay-ai/logs/codex-route-audit.jsonl` | Private (`0600`) metadata-only routing receipt for mixed mode; no prompts, headers, tools, tokens, or credentials |
 
 CLI files (`relay-ai-launch.config.toml`, `session.json`, `models-*.json`) are **separate**. Running CLI after app (or vice versa) should not break the other.
 
@@ -221,6 +227,37 @@ The catalog `display_name` uses human-readable labels (e.g. `Claude Haiku 4.5`).
 | Codex already running | relay-ai asks to **restart Codex** so new settings apply; you can decline and reopen manually |
 | Crash / killed terminal | Next launch auto-recovers when possible, or `relay-ai codex-app --restore` |
 | Live session still running | `--restore` refuses until you Ctrl+C the other terminal |
+
+Restoration is transaction-safe. If `config.toml` still matches the exact Relay
+patch, Relay restores the verified backup byte-for-byte. If ChatGPT or the user
+changed unrelated settings during the session, Relay removes only its owned
+overlay keys and preserves those concurrent edits. Writes are atomic and retain
+private file permissions.
+
+For an unattended `--yes` session, `SIGTERM` or `SIGHUP` restores the config,
+stops the proxy, and gracefully quits ChatGPT so the app is never left pointing
+at a dead local provider. A hard crash cannot run cleanup; once the Relay process
+is confirmed absent, recover with:
+
+```bash
+relay-ai codex-app --restore
+```
+
+Do not delete `config.toml`, the session lock, or the backup directory manually.
+If ChatGPT is configured as a login item, it can start independently after a
+login; keep it closed until a foreground Relay launch reports ready. A login
+agent should start Relay first and let Relay launch ChatGPT only after readiness,
+rather than starting both independently.
+
+### Verifying the real route
+
+Picker labels and model self-identification are not routing proof. Mixed-mode
+launches reset and append to `~/.relay-ai/logs/codex-route-audit.jsonl`. Each
+JSONL row records only the time, transport, requested model, native-vs-Relay
+dispatch, provider/upstream model, and outcome. Use its `complete` rows to prove
+that a native request reached OpenAI's native route or an external request
+reached the selected Relay provider. Full `--trace` is unnecessary for normal
+operation.
 
 ### App vs CLI — config safety
 
@@ -353,12 +390,14 @@ Codex exposes a **reasoning effort** picker when relay-ai's model catalog includ
 | Existing conversations disappear during a relay-ai session | Update relay-ai. Older releases selected a custom `model_provider`, so Codex filtered the sidebar to relay-ai-only threads. Current releases keep the built-in `openai` provider and preserve normal history visibility. |
 | App didn’t open | Open Codex manually once, run `relay-ai codex-app` again |
 | Model errors / disconnected | Keep relay-ai terminal open (proxy must run) |
+| Models appear but requests do not answer | Confirm the foreground Relay process is still running. Picker presence alone does not prove the proxy is alive; recover with `relay-ai codex-app --restore` only after the Relay process is confirmed absent. |
 | Stuck on relay-ai settings | `relay-ai codex-app --restore` |
 | `--restore` blocked | Ctrl+C the other relay-ai codex-app terminal first |
 | Wrong config after test | `--restore`; backups in `~/.relay-ai/codex/backups/` |
 | "prompt too long" / session crashes after many turns | The conversation history grew past the model’s context limit. Start a fresh conversation in Codex. relay-ai now sets `model_auto_compact_token_limit` in config.toml to prevent this going forward — see [Context management](#context-management-and-session-architecture). |
 | Trying to continue a large GPT-5.5 session on a different model | Codex sends the full conversation history inline; 1 M-token models reject 2 M-token payloads. relay-ai trims the oldest messages automatically, but some early context will be lost. Starting fresh is the cleanest option. |
 | Model shows as "Custom" in the Codex UI | Expected — Codex labels all external catalog models as "Custom". The correct model is in use. |
+| Need to prove which provider answered | Inspect `~/.relay-ai/logs/codex-route-audit.jsonl`; use `complete` rows, not the model's self-identification. |
 
 ### Shared
 

--- a/src/codex-app.ts
+++ b/src/codex-app.ts
@@ -24,6 +24,7 @@ import {
 } from './codex/routing.js';
 import { buildCodexAppProviderCatalogRoutes } from './codex/app-provider-routes.js';
 import { applyAppConfigPatch, previewAppConfigToml } from './codex/app-config.js';
+import { verifyCodexAppReadiness } from './codex/app-readiness.js';
 import { PREVIEW_PROXY_PORT, type CodexAppConfigSpec } from './codex/app-profile.js';
 import type { LocalProvider, LocalProviderModel } from './types.js';
 import {
@@ -32,6 +33,7 @@ import {
   getAppCatalogPath,
   getAppRestoreStatePath,
   getCodexConfigPath,
+  fileSha256,
   recoverInterruptedCodexAppSession,
   restoreCodexAppOverlay,
   saveAppRestoreStateBeforePatch,
@@ -66,6 +68,7 @@ import {
 } from './codex/favorites-launch.js';
 import { getFavoritesAppCatalogPath } from './codex/profile.js';
 import { getRelayAiCodexDir } from './codex/session.js';
+import { prepareCodexRouteAuditLog } from './codex/route-audit.js';
 import {
   buildCloudCodeProxyRoute,
   buildOAuthAnthropicProxyRoute,
@@ -94,11 +97,23 @@ function codexProxyRouteToCodexRoute(route: CodexProxyRoute, fallbackProviderId:
   };
 }
 
-export async function waitForShutdownWithConfirm(assumeYes = false): Promise<void> {
+export function codexAppUsesExplicitSelection(
+  configOnly: boolean,
+  launchProvider?: string,
+  launchModel?: string,
+): boolean {
+  // configOnly is intentionally accepted so the preview behavior stays an
+  // explicit, regression-tested part of this decision.
+  void configOnly;
+  return Boolean(launchProvider && launchModel);
+}
+
+type AppShutdownSignal = 'sigint' | 'sigterm' | 'sighup';
+
+async function waitForShutdownWithConfirm(): Promise<AppShutdownSignal> {
   while (true) {
     const signal = await waitForShutdown();
-    if (signal !== 'sigint') break; // SIGTERM/SIGHUP: close immediately, no one to ask
-    if (assumeYes) break; // unattended launch: no one to ask either
+    if (signal !== 'sigint') return signal; // SIGTERM/SIGHUP: close immediately, no one to ask
     console.log('');
     const choice = await p.select({
       message: 'Close ChatGPT Desktop and restore your Codex config?',
@@ -107,19 +122,17 @@ export async function waitForShutdownWithConfirm(assumeYes = false): Promise<voi
         { value: 'no', label: 'No, keep session running' },
       ],
     });
-    if (p.isCancel(choice) || choice === 'yes') break; // Ctrl+C or Yes = close
+    if (p.isCancel(choice) || choice === 'yes') return signal; // Ctrl+C or Yes = close
     // choice === 'no' → loop back and keep waiting
   }
 }
 
-export async function maybeCloseRunningCodexApp(assumeYes = false): Promise<void> {
-  if (!isCodexAppRunning()) return;
+export function unattendedShutdownClosesApp(assumeYes: boolean, signal: AppShutdownSignal): boolean {
+  return assumeYes && signal !== 'sigint';
+}
 
-  if (assumeYes) {
-    p.log.step('Stopping ChatGPT Desktop...');
-    quitCodexAppGracefully();
-    return;
-  }
+export async function maybeCloseRunningCodexApp(): Promise<void> {
+  if (!isCodexAppRunning()) return;
 
   const shouldClose = await p.confirm({ message: 'ChatGPT Desktop is still running. Close it?' });
   if (shouldClose && !p.isCancel(shouldClose)) {
@@ -145,7 +158,7 @@ ${pc.bold('Options:')}
   --vertex     Use Claude models through Google Vertex AI
   --with-native Load native Codex models beside Relay models for this launch
   --relay-only Keep the current Relay-only launch behavior
-  --yes, -y     Run a fully specified launch unattended (no launch/stop prompts)
+  --yes, -y     Approve a fully specified launch/restart without prompting
   --restore    Restore Codex config after an interrupted app session
   --config     Preview the generated Codex app configuration without launching
   --trace      Write proxy debug logs to ~/.relay-ai/logs/ and show errors on exit
@@ -291,8 +304,10 @@ async function runCodexAppVertexLaunch(configOnly: boolean, trace = false): Prom
     };
 
     saveAppRestoreStateBeforePatch();
+    sessionActive = true;
     const backupPath = backupConfigToml();
     applyAppConfigPatch(spec);
+    await verifyCodexAppReadiness(spec);
 
     writeAppSessionLock({
       pid: process.pid,
@@ -302,8 +317,9 @@ async function runCodexAppVertexLaunch(configOnly: boolean, trace = false): Prom
       restoreStatePath: getAppRestoreStatePath(),
       backupPath,
       proxyPort,
+      patchedConfigSha256: fileSha256(getCodexConfigPath()),
+      ...(backupPath ? { originalConfigSha256: fileSha256(backupPath) } : {}),
     });
-    sessionActive = true;
 
     p.log.info(`Vertex AI · ${selectedEntry.display_name} — project: ${config.project} / location: ${config.location}`);
     logCodexProxy(proxyPort);
@@ -314,6 +330,7 @@ async function runCodexAppVertexLaunch(configOnly: boolean, trace = false): Prom
     } catch (err) {
       p.log.warn(String(err instanceof Error ? err.message : err));
       p.log.info(codexAppInstallHint());
+      throw err;
     }
 
     printCodexAppSessionPanel({
@@ -442,11 +459,14 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
   let selectedModel = activeProvider.models.find(m => m.id === prefs.lastCodexModel)
     ?? activeProvider.models[0]!;
 
-  if (!configOnly && opts.launchProvider && opts.launchModel) {
+  // --config must preview the exact unattended launch selection. Ignoring
+  // explicit flags here made a safe preview silently show the previously saved
+  // model instead of the requested provider/model pair.
+  if (codexAppUsesExplicitSelection(configOnly, opts.launchProvider, opts.launchModel)) {
     const bootSelection = resolveBootSelection(
       compatible,
-      opts.launchProvider,
-      opts.launchModel,
+      opts.launchProvider!,
+      opts.launchModel!,
       providerForCodexPicker,
     );
     if ('error' in bootSelection) {
@@ -535,6 +555,12 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
         generalFavorites: favorites,
         subagentFavorites: prefs.codexSubagentModels ?? [],
       });
+      if (mixedModels.capacitySkipped.length > 0) {
+        p.log.warn(
+          `Skipped ${mixedModels.capacitySkipped.length} favorite(s) because the mixed catalog is full: `
+            + mixedModels.capacitySkipped.map(f => `${f.providerId}:${f.modelId}`).join(', '),
+        );
+      }
       assertConfiguredCodexSubagentsResolved(prefs.codexSubagentModels ?? [], mixedModels);
       const multiAgentV2Supported = mixedModels.subagents.length === 0 || supportsMultiAgentV2(embeddedBinary);
       if (!multiAgentV2Supported) {
@@ -651,10 +677,12 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     }
 
     let proxyPort: number;
+    const routeAuditPath = mixedPlan ? prepareCodexRouteAuditLog() : undefined;
     if (mixedPlan) {
       proxyHandle = await startCodexProxy(mixedPlan.relayRoutes, {
         requireAuth: false,
         debug: trace,
+        routeAuditPath,
         mixedNative: {
           nativeModelIds: mixedPlan.nativeModelIds,
           subagentRouteModelId: mixedPlan.subagentRouteModelId,
@@ -663,6 +691,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
         },
       });
       proxyPort = proxyHandle.port;
+      p.log.info(`Route audit (metadata only): ${routeAuditPath}`);
     } else if (favoritesActive && resolvedFavorites.length > 0) {
       const needsBackend = (r: typeof resolvedFavorites[0]) => {
         const m = r.model as LocalProviderModel;
@@ -735,8 +764,10 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     };
 
     saveAppRestoreStateBeforePatch();
+    sessionActive = true;
     const backupPath = backupConfigToml();
     applyAppConfigPatch(spec);
+    await verifyCodexAppReadiness(spec);
 
     writeAppSessionLock({
       pid: process.pid,
@@ -746,8 +777,9 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
       restoreStatePath: getAppRestoreStatePath(),
       backupPath,
       proxyPort,
+      patchedConfigSha256: fileSha256(getCodexConfigPath()),
+      ...(backupPath ? { originalConfigSha256: fileSha256(backupPath) } : {}),
     });
-    sessionActive = true;
 
     const prevRecent = prefs.recentModelsByProvider?.[activeProvider.id] ?? [];
     const updatedRecent = [selectedModel.id, ...prevRecent.filter(id => id !== selectedModel.id)].slice(0, 3);
@@ -766,6 +798,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     } catch (err) {
       p.log.warn(String(err instanceof Error ? err.message : err));
       p.log.info(codexAppInstallHint());
+      throw err;
     }
 
     printCodexAppSessionPanel({
@@ -776,7 +809,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     });
 
     codexAppOutro(modelLabel);
-    await waitForShutdownWithConfirm(opts.assumeYes);
+    const shutdownSignal = await waitForShutdownWithConfirm();
     if (trace) printTraceLog(debugLogPath);
     console.log('');
 
@@ -784,7 +817,14 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
       restoreCodexAppOverlay();
       sessionActive = false;
     }
-    await maybeCloseRunningCodexApp(opts.assumeYes);
+    if (unattendedShutdownClosesApp(Boolean(opts.assumeYes), shutdownSignal)) {
+      if (isCodexAppRunning()) {
+        p.log.step('Stopping ChatGPT Desktop after unattended Relay shutdown...');
+        quitCodexAppGracefully();
+      }
+    } else {
+      await maybeCloseRunningCodexApp();
+    }
     return 0;
   } finally {
     proxyHandle?.close();

--- a/src/codex-app.ts
+++ b/src/codex-app.ts
@@ -110,10 +110,11 @@ export function codexAppUsesExplicitSelection(
 
 type AppShutdownSignal = 'sigint' | 'sigterm' | 'sighup';
 
-async function waitForShutdownWithConfirm(): Promise<AppShutdownSignal> {
+export async function waitForShutdownWithConfirm(assumeYes = false): Promise<AppShutdownSignal> {
   while (true) {
     const signal = await waitForShutdown();
     if (signal !== 'sigint') return signal; // SIGTERM/SIGHUP: close immediately, no one to ask
+    if (assumeYes) return signal; // unattended launch: no one to ask either
     console.log('');
     const choice = await p.select({
       message: 'Close ChatGPT Desktop and restore your Codex config?',
@@ -131,8 +132,14 @@ export function unattendedShutdownClosesApp(assumeYes: boolean, signal: AppShutd
   return assumeYes && signal !== 'sigint';
 }
 
-export async function maybeCloseRunningCodexApp(): Promise<void> {
+export async function maybeCloseRunningCodexApp(assumeYes = false): Promise<void> {
   if (!isCodexAppRunning()) return;
+
+  if (assumeYes) {
+    p.log.step('Stopping ChatGPT Desktop...');
+    quitCodexAppGracefully();
+    return;
+  }
 
   const shouldClose = await p.confirm({ message: 'ChatGPT Desktop is still running. Close it?' });
   if (shouldClose && !p.isCancel(shouldClose)) {
@@ -809,7 +816,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
     });
 
     codexAppOutro(modelLabel);
-    const shutdownSignal = await waitForShutdownWithConfirm();
+    const shutdownSignal = await waitForShutdownWithConfirm(opts.assumeYes);
     if (trace) printTraceLog(debugLogPath);
     console.log('');
 
@@ -823,7 +830,7 @@ export async function runCodexAppCommand(args: string[], opts: { vertex?: boolea
         quitCodexAppGracefully();
       }
     } else {
-      await maybeCloseRunningCodexApp();
+      await maybeCloseRunningCodexApp(opts.assumeYes);
     }
     return 0;
   } finally {

--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -36,6 +36,7 @@ import {
   resolveRoutedCollaborationInput,
   stripCodexCollaborationTools,
 } from './codex/collaboration-payload.js';
+import { appendCodexRouteAudit } from './codex/route-audit.js';
 
 /**
  * Pull the full `response` object out of a single SSE event chunk if it's the
@@ -225,6 +226,8 @@ export interface CodexProxyRoute {
   apiKey: string;
   baseURL?: string;
   upstreamModelId: string;
+  /** Provider-facing model id recorded in the metadata-only route audit. */
+  auditUpstreamModelId?: string;
   providerId?: string;
   authType?: 'api' | 'oauth' | 'none';
   oauthAccountId?: string;
@@ -354,6 +357,8 @@ export interface CodexProxyOptions {
   debug?: boolean;
   /** Default true. App mode passes false — GUI cannot inherit RELAY_AI_CODEX_KEY. */
   requireAuth?: boolean;
+  /** Metadata-only request routing receipt. Never records prompts, headers, tools, or credentials. */
+  routeAuditPath?: string;
   mixedNative?: {
     nativeModelIds: ReadonlySet<string>;
     subagentRouteModelId?: string;
@@ -392,6 +397,33 @@ async function prepareExternalCodexBody(
   return { ...externalBody, input: resolvedInput };
 }
 
+/**
+ * Codex's developer context describes the host application, tools, and agent
+ * role. External models must retain those operating instructions, but must not
+ * infer from them that their own model is Codex, GPT, or OpenAI-hosted. Bind the
+ * selected Relay route explicitly at the final provider boundary so this stays
+ * correct for Gemini, Claude, OSS, and future dynamically discovered models.
+ */
+export function applyExternalCodexRuntimeIdentity(
+  params: CodexSdkCallParams,
+  route: Pick<CodexProxyRoute, 'modelId' | 'providerId' | 'upstreamModelId' | 'auditUpstreamModelId'>,
+): CodexSdkCallParams {
+  const selectedModel = route.auditUpstreamModelId ?? route.upstreamModelId ?? route.modelId;
+  const provider = route.providerId ?? 'relay';
+  const identity = [
+    '<external-model-identity>',
+    `The selected model for this turn is ${JSON.stringify(selectedModel)} through provider ${JSON.stringify(provider)}.`,
+    'Codex is the host application and agent environment, not the model identity.',
+    'Follow Codex host and tool instructions normally, but do not infer that you are an OpenAI or GPT model from host names, tool names, documentation, or conversation context.',
+    'If asked what model you are, report the selected model and provider above; do not use self-identification as evidence of the network route.',
+    '</external-model-identity>',
+  ].join('\n');
+  return {
+    ...params,
+    system: params.system?.trim() ? `${identity}\n\n${params.system}` : identity,
+  };
+}
+
 export async function startCodexProxy(
   routes: CodexProxyRoute[],
   options: CodexProxyOptions | boolean = {},
@@ -400,6 +432,9 @@ export async function startCodexProxy(
   const debug = opts.debug ?? false;
   const requireAuth = opts.requireAuth ?? true;
   const mixedNative = opts.mixedNative;
+  const audit = (event: Parameters<typeof appendCodexRouteAudit>[1]) => {
+    if (opts.routeAuditPath) appendCodexRouteAudit(opts.routeAuditPath, event);
+  };
   const nativePayloadRelay = mixedNative ? createNativePayloadRelay({}) : undefined;
   silenceSdkWarnings();
 
@@ -590,6 +625,7 @@ export async function startCodexProxy(
           log(`subagent dispatch: requested=${modelId} route=${subagentRoute?.modelId ?? '(none)'}`);
         }
         if (mixedNative && markedSubagent && !subagentRoute) {
+          audit({ transport: 'http', requestedModel: modelId, dispatch: 'relay-subagent', phase: 'complete', outcome: 'error', status: 503 });
           sendJson(res, 503, {
             error: {
               message: 'Codex marked this request as a Sub-agent, but no configured Codex Sub-agent route is available.',
@@ -602,10 +638,15 @@ export async function startCodexProxy(
           if (!markedSubagent) {
             const dispatch = classifyCodexDispatch(modelId, routes, mixedNative.nativeModelIds);
             if (dispatch.kind === 'unknown') {
+              audit({ transport: 'http', requestedModel: modelId, dispatch: 'unknown', phase: 'complete', outcome: 'error', status: 404 });
               sendJson(res, 404, { error: { message: `Unknown model: ${modelId}`, type: 'invalid_request_error' } });
               return;
             }
             if (dispatch.kind === 'native') {
+              audit({
+                transport: 'http', requestedModel: modelId, dispatch: 'native', phase: 'dispatch',
+                provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+              });
               const controller = new AbortController();
               req.once('aborted', () => controller.abort());
               try {
@@ -621,7 +662,17 @@ export async function startCodexProxy(
                 const contentType = nativeResponse.headers.get('content-type');
                 res.writeHead(nativeResponse.status, contentType ? { 'content-type': contentType } : undefined);
                 res.end(Buffer.from(await nativeResponse.arrayBuffer()));
+                audit({
+                  transport: 'http', requestedModel: modelId, dispatch: 'native', phase: 'complete',
+                  provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+                  outcome: nativeResponse.ok ? 'ok' : 'error', status: nativeResponse.status,
+                });
               } catch (err) {
+                audit({
+                  transport: 'http', requestedModel: modelId, dispatch: 'native', phase: 'complete',
+                  provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+                  outcome: 'error', status: 'forward-failed',
+                });
                 if (!res.writableEnded) sendJson(res, 502, { error: { message: 'Native Codex request failed', type: 'upstream_error' } });
               }
               return;
@@ -649,6 +700,12 @@ export async function startCodexProxy(
         }
 
         const { route, languageModel } = resolved;
+        const relayDispatch = markedSubagent ? 'relay-subagent' as const : 'relay' as const;
+        audit({
+          transport: 'http', requestedModel: modelId, dispatch: relayDispatch, phase: 'dispatch',
+          provider: route.providerId ?? 'relay', routeModel: route.modelId,
+          upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+        });
 
         try {
           const routedBody = await prepareExternalCodexBody(body, {
@@ -656,7 +713,7 @@ export async function startCodexProxy(
             mixedNative,
             headers: req.headers,
           });
-          let params = applyClaudeCodeOAuthIdentity(route, translateResponsesRequest(
+          let params = applyClaudeCodeOAuthIdentity(route, applyExternalCodexRuntimeIdentity(translateResponsesRequest(
             routedBody as unknown as import('./codex-responses-adapter.js').ResponsesRequest,
             route.npm,
             {
@@ -668,7 +725,7 @@ export async function startCodexProxy(
               upstreamModelId: route.upstreamModelId,
             },
             { maxTools: maxToolsForNpm(route.npm) },
-          ));
+          ), route));
           if (route.contextWindow && route.contextWindow > 0) {
             const before = params.messages.length;
             const estimatedChars = estimateCodexRequestChars(params);
@@ -726,9 +783,19 @@ export async function startCodexProxy(
                   log(`response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
                 }
               });
+              audit({
+                transport: 'http', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
+                provider: route.providerId ?? 'relay', routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId, outcome: 'ok', status: 200,
+              });
             } catch (err) {
               const msg = formatUpstreamError(err);
               const status = upstreamHttpStatus(err, msg);
+              audit({
+                transport: 'http', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
+                provider: route.providerId ?? 'relay', routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId, outcome: 'error', status,
+              });
               if (debug) log(`sdk error: ${route.modelId}: ${msg}`);
               if (status === 429) {
                 writeResponsesRateLimitStream(modelId, msg, write);
@@ -752,9 +819,19 @@ export async function startCodexProxy(
                 });
               }
               sendJson(res, 200, response);
+              audit({
+                transport: 'http', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
+                provider: route.providerId ?? 'relay', routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId, outcome: 'ok', status: 200,
+              });
             } catch (err) {
               const msg = formatUpstreamError(err);
               const status = upstreamHttpStatus(err, msg);
+              audit({
+                transport: 'http', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
+                provider: route.providerId ?? 'relay', routeModel: route.modelId,
+                upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId, outcome: 'error', status,
+              });
               if (debug) log(`sdk error: ${route.modelId}: ${msg}`);
               if (status === 429) {
                 sendJson(res, 200, responsesRateLimitBody(modelId, msg));
@@ -1011,6 +1088,7 @@ export async function startCodexProxy(
             log(`WS subagent dispatch: requested=${modelId} route=${subagentRoute?.modelId ?? '(none)'}`);
           }
           if (mixedNative && markedSubagent && !subagentRoute) {
+            audit({ transport: 'ws', requestedModel: modelId, dispatch: 'relay-subagent', phase: 'complete', outcome: 'error', status: 503 });
             sendWsEvent(`event: error\ndata: ${JSON.stringify({ error: {
               message: 'Codex marked this request as a Sub-agent, but no configured Codex Sub-agent route is available.',
               type: 'service_unavailable',
@@ -1022,11 +1100,16 @@ export async function startCodexProxy(
             if (!markedSubagent) {
               const dispatch = classifyCodexDispatch(modelId, routes, mixedNative.nativeModelIds);
               if (dispatch.kind === 'unknown') {
+                audit({ transport: 'ws', requestedModel: modelId, dispatch: 'unknown', phase: 'complete', outcome: 'error', status: 404 });
                 sendWsEvent(`event: error\ndata: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: 'invalid_request_error' } })}\n\n`);
                 closeSocket();
                 return;
               }
               if (dispatch.kind === 'native') {
+                audit({
+                  transport: 'ws', requestedModel: modelId, dispatch: 'native', phase: 'dispatch',
+                  provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+                });
                 const nativeBody = prepareNativeCodexBody(body);
                 if (debug && nativeBody !== body) {
                   log(`WS native history normalized: model=${modelId} converted Relay compaction for native verification`);
@@ -1071,6 +1154,13 @@ export async function startCodexProxy(
                   if (debug && message) {
                     log(`WS native upstream failed: model=${modelId} opened=${nativeOpened} frames=${nativeFrameCount} message=${message}`);
                   }
+                  if (message && !nativeCompleted) {
+                    audit({
+                      transport: 'ws', requestedModel: modelId, dispatch: 'native', phase: 'complete',
+                      provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+                      outcome: 'error', status: 'upstream-failed',
+                    });
+                  }
                   if (message && !nativeCompleted) sendNativeError(message);
                   try { upstream?.close(); } catch { /* ignore */ }
                   closeSocket(closeCode);
@@ -1108,6 +1198,11 @@ export async function startCodexProxy(
                       if (typeof parsed.type === 'string') eventType = parsed.type;
                       if (eventType === 'response.completed' || eventType === 'response.failed' || eventType === 'response.incomplete') {
                         nativeCompleted = true;
+                        audit({
+                          transport: 'ws', requestedModel: modelId, dispatch: 'native', phase: 'complete',
+                          provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+                          outcome: eventType === 'response.completed' ? 'ok' : 'error', status: eventType,
+                        });
                       }
                     } catch { /* forward the native frame unchanged */ }
                     if (debug && (nativeFrameCount <= 3 || nativeCompleted || eventType === 'error' || nativeFrameCount % 25 === 0)) {
@@ -1154,13 +1249,19 @@ export async function startCodexProxy(
           }
 
           const { route, languageModel } = resolved;
+          const relayDispatch = markedSubagent ? 'relay-subagent' as const : 'relay' as const;
+          audit({
+            transport: 'ws', requestedModel: modelId, dispatch: relayDispatch, phase: 'dispatch',
+            provider: route.providerId ?? 'relay', routeModel: route.modelId,
+            upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
+          });
           try {
             const routedBody = await prepareExternalCodexBody(body, {
               relay: nativePayloadRelay,
               mixedNative,
               headers: req.headers,
             });
-            let params = applyClaudeCodeOAuthIdentity(route, translateResponsesRequest(
+            let params = applyClaudeCodeOAuthIdentity(route, applyExternalCodexRuntimeIdentity(translateResponsesRequest(
               routedBody as unknown as import('./codex-responses-adapter.js').ResponsesRequest,
               route.npm,
               {
@@ -1172,7 +1273,7 @@ export async function startCodexProxy(
                 upstreamModelId: route.upstreamModelId,
               },
               { maxTools: maxToolsForNpm(route.npm) },
-            ));
+            ), route));
             if (route.contextWindow && route.contextWindow > 0) {
               const before = params.messages.length;
               const estimatedChars = estimateCodexRequestChars(params);
@@ -1205,9 +1306,19 @@ export async function startCodexProxy(
                 log(`WS response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
               }
             });
+            audit({
+              transport: 'ws', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
+              provider: route.providerId ?? 'relay', routeModel: route.modelId,
+              upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId, outcome: 'ok', status: 'response.completed',
+            });
           } catch (err) {
             const msg = formatUpstreamError(err);
             const status = upstreamHttpStatus(err, msg);
+            audit({
+              transport: 'ws', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
+              provider: route.providerId ?? 'relay', routeModel: route.modelId,
+              upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId, outcome: 'error', status,
+            });
             if (debug) log(`WS sdk error: ${route.modelId}: ${msg}`);
             if (status === 429) {
               writeResponsesRateLimitStream(modelId, msg, sendWsEvent);

--- a/src/codex/app-config.ts
+++ b/src/codex/app-config.ts
@@ -9,6 +9,7 @@ import {
 } from './app-profile.js';
 import { getReasoningCapabilities } from '../provider-factory.js';
 import { getCodexHome } from './session.js';
+import { atomicWriteFile } from './session.js';
 
 export type TomlRecord = Record<string, unknown>;
 
@@ -236,7 +237,12 @@ export function applyAppConfigPatch(spec: CodexAppConfigSpec, configPath = getCo
   const text = `${stringify(merged)}\n`;
   validateAppConfigText(text, spec);
   mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, text, 'utf8');
+  atomicWriteFile(configPath, text);
+  const written = readCodexConfigText(configPath);
+  if (written !== text) {
+    throw new Error(`Codex config readback mismatch at ${configPath}`);
+  }
+  validateAppConfigText(written, spec);
   return text;
 }
 

--- a/src/codex/app-launch.ts
+++ b/src/codex/app-launch.ts
@@ -1,5 +1,5 @@
 // Find, open, quit, and restart the ChatGPT desktop app / Codex mode (macOS + Windows + Linux).
-import { execSync, spawn } from 'node:child_process';
+import { execFileSync, execSync, spawn } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, readdirSync, realpathSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, win32 as winPath } from 'node:path';
@@ -224,6 +224,45 @@ function darwinIsRunning(): boolean {
   });
 }
 
+function pgrepExact(names: readonly string[]): number[] {
+  const pids = new Set<number>();
+  for (const name of names) {
+    try {
+      for (const raw of run(`pgrep -x ${JSON.stringify(name)}`).split(/\s+/)) {
+        const pid = Number.parseInt(raw, 10);
+        if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) pids.add(pid);
+      }
+    } catch { /* process name is not running */ }
+  }
+  return [...pids];
+}
+
+export function darwinMainExecutableCandidates(appPath: string): string[] {
+  return DARWIN_APP_NAMES.map(name => join(appPath, 'Contents', 'MacOS', name));
+}
+
+function pgrepExactCommand(commands: readonly string[]): number[] {
+  const pids = new Set<number>();
+  for (const command of commands) {
+    try {
+      const out = execFileSync('pgrep', ['-f', `^${command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      for (const raw of out.split(/\s+/)) {
+        const pid = Number.parseInt(raw, 10);
+        if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) pids.add(pid);
+      }
+    } catch { /* exact command is not running */ }
+  }
+  return [...pids];
+}
+
+function darwinMatchingPids(): number[] {
+  const appPath = findCodexApp('darwin');
+  return appPath ? pgrepExactCommand(darwinMainExecutableCandidates(appPath)) : [];
+}
+
 function linuxIsRunning(): boolean {
   for (const name of ['ChatGPT', 'chatgpt']) {
     try {
@@ -231,6 +270,10 @@ function linuxIsRunning(): boolean {
     } catch { /* app is not running */ }
   }
   return false;
+}
+
+function linuxMatchingPids(): number[] {
+  return pgrepExact(['ChatGPT', 'chatgpt']);
 }
 
 function winMatchingPids(): number[] {
@@ -269,26 +312,37 @@ export function isCodexAppRunning(): boolean {
   return false;
 }
 
+export function codexAppMainPids(platform: NodeJS.Platform = process.platform): number[] {
+  if (platform === 'darwin') return darwinMatchingPids();
+  if (platform === 'win32') return winMatchingPids();
+  if (platform === 'linux') return linuxMatchingPids();
+  return [];
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function waitForQuit(timeoutMs: number): Promise<boolean> {
+export async function waitForOriginalCodexPids(
+  originalPids: readonly number[],
+  timeoutMs: number,
+  alive: (pid: number) => boolean = pidIsAlive,
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    // Check actual process existence, not window visibility — apps that
-    // minimize to the tray on close clear their window handle immediately
-    // while staying alive, which would make this return early with the
-    // old process (and its old config) still running.
-    if (process.platform === 'win32') {
-      if (winMatchingPids().length === 0) return true;
-    } else if (process.platform === 'linux' ? !linuxIsRunning() : !darwinIsRunning()) {
-      return true;
-    }
+    if (originalPids.every(pid => !alive(pid))) return true;
     await sleep(200);
   }
-  if (process.platform === 'win32') return winMatchingPids().length === 0;
-  return process.platform === 'linux' ? !linuxIsRunning() : !darwinIsRunning();
+  return originalPids.every(pid => !alive(pid));
 }
 
 function openCodexAppAt(path: string): void {
@@ -325,12 +379,15 @@ export function openCodexApp(): void {
   openCodexAppAt(path);
 }
 
+export function darwinQuitAppleScript(): string {
+  // The product name changed from Codex to ChatGPT while the bundle id stayed
+  // stable. Addressing the obsolete name can return success without signaling
+  // the running ChatGPT process, so always target the bundle identifier.
+  return `tell application id "${CODEX_BUNDLE_ID}" to quit`;
+}
+
 function darwinQuit(): void {
-  try {
-    execSync('osascript -e \'tell application "Codex" to quit\'', { stdio: 'pipe' });
-  } catch {
-    execSync(`osascript -e 'tell application id "${CODEX_BUNDLE_ID}" to quit'`, { stdio: 'pipe' });
-  }
+  execFileSync('osascript', ['-e', darwinQuitAppleScript()], { stdio: 'pipe' });
 }
 
 function winQuitGraceful(): void {
@@ -355,10 +412,19 @@ export function quitCodexAppGracefully(): void {
   else if (process.platform === 'linux') linuxQuitGraceful();
 }
 
-function winForceQuit(): void {
-  const pids = winMatchingPids();
+function winForceQuit(pids = winMatchingPids()): void {
   if (pids.length === 0) return;
   runPowerShell(`Stop-Process -Id ${pids.join(',')} -Force -ErrorAction SilentlyContinue`);
+}
+
+export function restartTimeoutAction(platform: NodeJS.Platform): 'force-quit' | 'fail-closed' {
+  return platform === 'win32' ? 'force-quit' : 'fail-closed';
+}
+
+export function gracefulQuitTimeoutMs(platform: NodeJS.Platform): number {
+  // ChatGPT for macOS waits for active Codex task plumbing to settle before
+  // terminating. Five seconds races that normal graceful path on a live task.
+  return platform === 'darwin' ? 30_000 : 5_000;
 }
 
 export async function launchOrRestartCodexApp(
@@ -366,6 +432,7 @@ export async function launchOrRestartCodexApp(
   assumeYes = false,
 ): Promise<void> {
   const appPath = findCodexApp();
+  const originalPids = codexAppMainPids();
   if (!isCodexAppRunning()) {
     if (!appPath) {
       throw new Error(
@@ -374,6 +441,9 @@ export async function launchOrRestartCodexApp(
     }
     openCodexAppAt(appPath);
     return;
+  }
+  if (originalPids.length === 0) {
+    throw new Error('ChatGPT Desktop is running but Relay could not identify its main process; refusing an unsafe restart.');
   }
 
   // Linux desktop apps can remain alive in the tray after their main window
@@ -397,10 +467,22 @@ export async function launchOrRestartCodexApp(
     else if (process.platform === 'win32') winQuitGraceful();
   }
 
-  if (!(await waitForQuit(5000))) {
-    if (process.platform === 'win32') winForceQuit();
-    await waitForQuit(5000);
+  const gracefulTimeout = gracefulQuitTimeoutMs(process.platform);
+  if (!(await waitForOriginalCodexPids(originalPids, gracefulTimeout))) {
+    if (restartTimeoutAction(process.platform) === 'force-quit') {
+      winForceQuit(originalPids);
+      if (!(await waitForOriginalCodexPids(originalPids, 5000))) {
+        throw new Error('ChatGPT Desktop did not exit after its force-quit timeout; refusing to launch a duplicate process.');
+      }
+    } else {
+      throw new Error('ChatGPT Desktop did not exit after graceful shutdown; refusing to relaunch or force-quit it.');
+    }
   }
+
+  // A login item or app supervisor may relaunch ChatGPT immediately after the
+  // original PID exits. That replacement already loaded Relay's validated
+  // temporary config, so keep the proxy alive and never open a duplicate.
+  if (isCodexAppRunning()) return;
 
   if (appPath) openCodexAppAt(appPath);
   else openCodexApp();

--- a/src/codex/app-readiness.ts
+++ b/src/codex/app-readiness.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import type { CodexCatalogFile } from './catalog.js';
+import { readCodexConfigText, validateAppConfigText } from './app-config.js';
+import type { CodexAppConfigSpec } from './app-profile.js';
+
+type FetchLike = typeof fetch;
+
+function proxyRoot(spec: CodexAppConfigSpec): string {
+  const base = spec.proxyBaseUrl ?? `http://127.0.0.1:${spec.proxyPort}/v1`;
+  if (!base.endsWith('/v1')) throw new Error('Codex App proxy base URL must end in /v1');
+  return base.slice(0, -3);
+}
+
+async function checkedJson(url: string, fetchImpl: FetchLike): Promise<unknown> {
+  const response = await fetchImpl(url);
+  if (!response.ok) throw new Error(`Relay readiness check failed: GET ${url} returned HTTP ${response.status}`);
+  return response.json();
+}
+
+/** Verify every dependency Codex Desktop will read before the app is launched. */
+export async function verifyCodexAppReadiness(
+  spec: CodexAppConfigSpec,
+  options: { configPath?: string; fetchImpl?: FetchLike } = {},
+): Promise<void> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const root = proxyRoot(spec);
+
+  const health = await checkedJson(`${root}/health`, fetchImpl) as { ok?: unknown };
+  if (health.ok !== true) throw new Error('Relay proxy health check did not report ready');
+
+  const catalog = JSON.parse(readFileSync(spec.catalogPath, 'utf8')) as Partial<CodexCatalogFile>;
+  if (!Array.isArray(catalog.models) || catalog.models.length === 0) {
+    throw new Error('Relay Codex model catalog is empty or invalid');
+  }
+  const catalogIds = catalog.models.map(model => model?.slug).filter((id): id is string => typeof id === 'string' && id.length > 0);
+  if (catalogIds.length !== catalog.models.length) throw new Error('Relay Codex model catalog contains an invalid model slug');
+  if (!catalogIds.includes(spec.route.modelId)) {
+    throw new Error(`Relay Codex model catalog is missing selected model ${spec.route.modelId}`);
+  }
+
+  const advertised = await checkedJson(`${root}/v1/models`, fetchImpl) as { data?: Array<{ id?: unknown }> };
+  const advertisedIds = new Set((advertised.data ?? []).map(model => model.id).filter((id): id is string => typeof id === 'string'));
+  for (const id of catalogIds) {
+    if (!advertisedIds.has(id)) throw new Error(`Relay proxy does not advertise catalog model ${id}`);
+  }
+
+  validateAppConfigText(readCodexConfigText(options.configPath), spec);
+}

--- a/src/codex/app-session.ts
+++ b/src/codex/app-session.ts
@@ -9,6 +9,7 @@ import {
   statSync,
 } from 'node:fs';
 import { basename, join } from 'node:path';
+import { createHash } from 'node:crypto';
 import {
   atomicWriteFile,
   getRelayAiCodexDir,
@@ -50,6 +51,13 @@ export interface CodexAppSessionLock {
   restoreStatePath: string;
   backupPath?: string;
   proxyPort?: number;
+  /** Hashes bind exact-byte restoration to the files this session actually wrote. */
+  patchedConfigSha256?: string;
+  originalConfigSha256?: string;
+}
+
+export function fileSha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
 export function readAppSessionLock(env: NodeJS.ProcessEnv = process.env): CodexAppSessionLock | null {
@@ -177,7 +185,19 @@ export function restoreCodexAppOverlay(env: NodeJS.ProcessEnv = process.env): Re
     return { restored: false, message: 'Nothing to restore.' };
   }
 
-  if (restoreState) {
+  const exactBackupIsSafe = Boolean(
+    managed
+    && lock?.backupPath
+    && existsSync(lock.backupPath)
+    && lock.patchedConfigSha256
+    && lock.originalConfigSha256
+    && fileSha256(getCodexConfigPath()) === lock.patchedConfigSha256
+    && fileSha256(lock.backupPath) === lock.originalConfigSha256,
+  );
+
+  if (exactBackupIsSafe) {
+    copyFileSync(lock!.backupPath!, getCodexConfigPath());
+  } else if (restoreState) {
     restoreConfigFromState(restoreState);
   } else if (lock?.backupPath && existsSync(lock.backupPath)) {
     copyFileSync(lock.backupPath, getCodexConfigPath());

--- a/src/codex/favorites-launch.ts
+++ b/src/codex/favorites-launch.ts
@@ -172,6 +172,7 @@ export interface ResolvedCodexMixedModels {
   all: ResolvedFavorite[];
   providersById: Map<string, LocalProvider>;
   dropped: FavoriteModel[];
+  capacitySkipped: FavoriteModel[];
 }
 
 /**
@@ -230,5 +231,6 @@ export async function resolveCodexMixedModels(input: {
     all,
     providersById: new Map(input.compatible.map(provider => [provider.id, provider])),
     dropped: [...visibleResult.droppedFavorites, ...subagentResult.droppedFavorites],
+    capacitySkipped: [...visibleResult.capacitySkippedFavorites, ...subagentResult.capacitySkippedFavorites],
   };
 }

--- a/src/codex/mixed-launch.ts
+++ b/src/codex/mixed-launch.ts
@@ -68,6 +68,7 @@ export async function prepareCodexMixedRelayRoutes(
         apiKey: backend.token,
         baseURL: `http://127.0.0.1:${backend.port}`,
         upstreamModelId: proxyRoute.aliasId,
+        auditUpstreamModelId: original.model.upstreamModelId || original.model.id,
         providerId: original.providerId,
         authType: 'oauth' as const,
         oauthAccountId: original.oauthAccountId,

--- a/src/codex/route-audit.ts
+++ b/src/codex/route-audit.ts
@@ -1,0 +1,65 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getLogsPath } from '../paths.js';
+
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+export const CODEX_ROUTE_AUDIT_LOG = 'codex-route-audit.jsonl';
+
+export type CodexRouteAuditTransport = 'http' | 'ws';
+export type CodexRouteAuditDispatch = 'native' | 'relay' | 'relay-subagent' | 'unknown';
+export type CodexRouteAuditPhase = 'dispatch' | 'complete';
+
+export interface CodexRouteAuditEvent {
+  transport: CodexRouteAuditTransport;
+  requestedModel: string;
+  dispatch: CodexRouteAuditDispatch;
+  phase: CodexRouteAuditPhase;
+  provider?: string;
+  routeModel?: string;
+  upstreamModel?: string;
+  outcome?: 'ok' | 'error';
+  status?: number | string;
+}
+
+function safeIdentifier(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return value.replace(/[\u0000-\u001f\u007f]/g, '_').slice(0, 300);
+}
+
+export function sanitizeCodexRouteAuditEvent(event: CodexRouteAuditEvent): Record<string, unknown> {
+  return {
+    ts: new Date().toISOString(),
+    transport: event.transport,
+    requestedModel: safeIdentifier(event.requestedModel),
+    dispatch: event.dispatch,
+    phase: event.phase,
+    ...(event.provider ? { provider: safeIdentifier(event.provider) } : {}),
+    ...(event.routeModel ? { routeModel: safeIdentifier(event.routeModel) } : {}),
+    ...(event.upstreamModel ? { upstreamModel: safeIdentifier(event.upstreamModel) } : {}),
+    ...(event.outcome ? { outcome: event.outcome } : {}),
+    ...(event.status !== undefined ? { status: typeof event.status === 'string' ? safeIdentifier(event.status) : event.status } : {}),
+  };
+}
+
+export function getCodexRouteAuditLogPath(): string {
+  const dir = getLogsPath();
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  try { chmodSync(dir, DIR_MODE); } catch { /* best-effort */ }
+  return join(dir, CODEX_ROUTE_AUDIT_LOG);
+}
+
+export function prepareCodexRouteAuditLog(path = getCodexRouteAuditLogPath()): string {
+  writeFileSync(path, '', { mode: FILE_MODE });
+  chmodSync(path, FILE_MODE);
+  return path;
+}
+
+export function appendCodexRouteAudit(path: string, event: CodexRouteAuditEvent): void {
+  try {
+    writeFileSync(path, `${JSON.stringify(sanitizeCodexRouteAuditEvent(event))}\n`, { flag: 'a', mode: FILE_MODE });
+    chmodSync(path, FILE_MODE);
+  } catch {
+    // Route auditing is evidence-only and must not interrupt a live request.
+  }
+}

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -132,7 +132,7 @@ ${pc.bold('Subcommands:')}
   (none)      Provider hub wizard ${pc.dim('[Phase 1.1]')}
   add         Add a provider (Groq, Mistral, Together AI, …) ${pc.dim('[Phase 1.1]')}
   import      Optional one-time import from OpenCode CLI ${pc.dim('[Phase 1.0]')}
-  auth        Sign in with OAuth (GitHub Copilot, xAI, OpenAI, ClinePass)
+  auth        Sign in with OAuth (Antigravity, GitHub Copilot, xAI, OpenAI, ClinePass)
   list        Show configured providers ${pc.dim('[Phase 1.0]')}
   remove      Remove a provider by id ${pc.dim('[Phase 1.1]')}
   refresh-models  Update cached model lists ${pc.dim('[Phase 1.2]')}`;

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -311,12 +311,16 @@ ${pc.bold('Usage:')}
   relay-ai providers auth openai-oauth
   relay-ai providers auth github-copilot
   relay-ai providers auth cline-pass
+  relay-ai providers auth antigravity
 
 ${pc.bold('Device code (works on SSH/VPS):')}
   xai-oauth        SuperGrok / X Premium (device code at x.ai/device)
   openai-oauth     ChatGPT Plus/Pro (device code at auth.openai.com/codex/device)
   github-copilot   GitHub Copilot Free or paid (device code at github.com/login/device)
   cline-pass       ClinePass account (device code at app.cline.bot)
+
+${pc.bold('Browser sign-in:')}
+  antigravity      Google Cloud Code Assist OAuth (opens Google sign-in)
 
 ${pc.dim('OpenCode CLI configs: use')} relay-ai providers import${pc.dim(' (optional one-time migration).')}`;
 }

--- a/tests/antigravity-launch-ide.test.ts
+++ b/tests/antigravity-launch-ide.test.ts
@@ -28,7 +28,7 @@ vi.mock('node:child_process', () => {
 });
 
 describe('antigravity launch-ide', () => {
-  it('finds standalone Antigravity app binary on macOS', () => {
+  it.skipIf(!findAntigravityAppBinary())('finds standalone Antigravity app binary on macOS when the optional GUI is installed', () => {
     const bin = findAntigravityAppBinary();
     expect(bin).toBeDefined();
     if (process.platform === 'darwin') {
@@ -95,7 +95,7 @@ describe('antigravity launch-ide', () => {
     fs.rmSync(tempProfile, { recursive: true, force: true });
   });
 
-  it('finds antigravity ide binary on macOS', () => {
+  it.skipIf(!findAntigravityIdeBinary())('finds antigravity ide binary on macOS when the optional GUI is installed', () => {
     // If not on mac, we might get null, but we can verify the path resolution logic
     const bin = findAntigravityIdeBinary();
     expect(bin).toBeDefined();

--- a/tests/codex-app-launch.test.ts
+++ b/tests/codex-app-launch.test.ts
@@ -3,8 +3,13 @@ import { readFileSync } from 'node:fs';
 import {
   codexAppInstallHint,
   codexAppSupported,
+  darwinQuitAppleScript,
+  darwinMainExecutableCandidates,
   linuxCodexAppCandidates,
   linuxEmbeddedCodexCandidates,
+  restartTimeoutAction,
+  gracefulQuitTimeoutMs,
+  waitForOriginalCodexPids,
   windowsEmbeddedCodexCachePath,
   windowsEmbeddedCodexCandidates,
 } from '../src/codex/app-launch.js';
@@ -43,6 +48,43 @@ describe('Linux ChatGPT desktop launcher', () => {
     const source = readFileSync(new URL('../src/codex/app-launch.ts', import.meta.url), 'utf8');
     expect(source).toContain('Restarting ChatGPT Desktop to apply relay-ai settings...');
     expect(source).toContain('linuxQuitGraceful();');
+  });
+});
+
+describe('ChatGPT desktop restart safety', () => {
+  it('identifies the main macOS executable by full path, not the truncated process name', () => {
+    expect(darwinMainExecutableCandidates('/Applications/ChatGPT.app')).toEqual([
+      '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+      '/Applications/ChatGPT.app/Contents/MacOS/Codex',
+    ]);
+  });
+
+  it('targets the stable macOS bundle id instead of the deprecated Codex app name', () => {
+    expect(darwinQuitAppleScript()).toBe('tell application id "com.openai.codex" to quit');
+    expect(darwinQuitAppleScript()).not.toContain('application "Codex"');
+  });
+
+  it('fails closed on macOS when graceful quit times out', () => {
+    expect(restartTimeoutAction('darwin')).toBe('fail-closed');
+  });
+
+  it('allows macOS Codex tasks a bounded 30-second graceful shutdown window', () => {
+    expect(gracefulQuitTimeoutMs('darwin')).toBe(30_000);
+    expect(gracefulQuitTimeoutMs('win32')).toBe(5_000);
+  });
+
+  it('retains the guarded Windows force-quit fallback', () => {
+    expect(restartTimeoutAction('win32')).toBe('force-quit');
+  });
+
+  it('accepts an immediate replacement PID once the original app PID exits', async () => {
+    const alivePids = new Set([202]);
+    await expect(waitForOriginalCodexPids([101], 0, pid => alivePids.has(pid))).resolves.toBe(true);
+  });
+
+  it('does not confuse a still-running original PID with a replacement', async () => {
+    const alivePids = new Set([101, 202]);
+    await expect(waitForOriginalCodexPids([101], 0, pid => alivePids.has(pid))).resolves.toBe(false);
   });
 });
 

--- a/tests/codex-app-readiness.test.ts
+++ b/tests/codex-app-readiness.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applyAppConfigPatch } from '../src/codex/app-config.js';
+import { verifyCodexAppReadiness } from '../src/codex/app-readiness.js';
+import type { CodexAppConfigSpec } from '../src/codex/app-profile.js';
+
+describe('Codex App startup readiness regression protections', () => {
+  let home: string;
+  let configPath: string;
+  let catalogPath: string;
+  let spec: CodexAppConfigSpec;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'relay-app-ready-'));
+    configPath = join(home, '.codex', 'config.toml');
+    catalogPath = join(home, '.relay-ai', 'codex', 'app-models-mixed.json');
+    mkdirSync(join(home, '.codex'), { recursive: true });
+    mkdirSync(join(home, '.relay-ai', 'codex'), { recursive: true });
+    writeFileSync(configPath, 'model = "gpt-native"\n', 'utf8');
+    writeFileSync(catalogPath, JSON.stringify({ models: [{ slug: 'antigravity__gemini-pro' }, { slug: 'gpt-native' }] }), 'utf8');
+    spec = {
+      route: {
+        tier: 'proxy', npm: '', apiKey: '', upstreamModelId: '',
+        modelId: 'antigravity__gemini-pro', providerId: 'antigravity',
+      },
+      proxyPort: 43210,
+      proxyBaseUrl: 'http://127.0.0.1:43210/_relay-codex/capability/v1',
+      catalogPath,
+    };
+    applyAppConfigPatch(spec, configPath);
+  });
+
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  function readyFetch(): typeof fetch {
+    return vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/health')) return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({
+        object: 'list',
+        data: [{ id: 'antigravity__gemini-pro' }, { id: 'gpt-native' }],
+      }), { status: 200 });
+    }) as typeof fetch;
+  }
+
+  it('requires proxy health, advertised mixed catalog, and patched config readback before launch', async () => {
+    await expect(verifyCodexAppReadiness(spec, { configPath, fetchImpl: readyFetch() })).resolves.toBeUndefined();
+  });
+
+  it('blocks launch when the proxy is not healthy', async () => {
+    const fetchImpl = vi.fn(async () => new Response('offline', { status: 503 })) as typeof fetch;
+    await expect(verifyCodexAppReadiness(spec, { configPath, fetchImpl })).rejects.toThrow(/HTTP 503/);
+  });
+
+  it('blocks the false-positive picker when a catalog model is not routed', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => String(input).endsWith('/health')
+      ? new Response(JSON.stringify({ ok: true }), { status: 200 })
+      : new Response(JSON.stringify({ data: [{ id: 'gpt-native' }] }), { status: 200 })) as typeof fetch;
+    await expect(verifyCodexAppReadiness(spec, { configPath, fetchImpl })).rejects.toThrow(/does not advertise.*gemini-pro/);
+  });
+
+  it('blocks launch if config.toml no longer matches the validated Relay session', async () => {
+    writeFileSync(configPath, 'model = "gpt-native"\n', 'utf8');
+    await expect(verifyCodexAppReadiness(spec, { configPath, fetchImpl: readyFetch() })).rejects.toThrow(/Generated config/);
+  });
+
+  it('writes config atomically with private permissions and exact readback', () => {
+    expect(readFileSync(configPath, 'utf8')).toContain('antigravity__gemini-pro');
+    // POSIX mode assertion is intentionally bounded to macOS/Linux.
+    if (process.platform !== 'win32') {
+      const { mode } = statSync(configPath);
+      expect(mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/tests/codex-app-session.test.ts
+++ b/tests/codex-app-session.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   getAppRestoreStatePath,
+  backupConfigToml,
+  fileSha256,
   getCodexConfigPath,
   restoreCodexAppOverlay,
   saveAppRestoreStateBeforePatch,
@@ -77,5 +79,60 @@ describe('codex app session', () => {
     expect(readFileSync(configPath, 'utf8')).toContain('model = "gpt-5"');
     expect(readFileSync(configPath, 'utf8')).toContain('model_provider = "openai"');
     expect(existsSync(getAppRestoreStatePath())).toBe(false);
+  });
+
+  it('restores the original config byte-for-byte when the Relay patch did not change concurrently', () => {
+    const configPath = getCodexConfigPath();
+    mkdirSync(join(home, '.codex'), { recursive: true });
+    const original = '# preserve formatting exactly\nmodel="gpt-5"\nmodel_provider = "openai"\n';
+    writeFileSync(configPath, original, 'utf8');
+
+    saveAppRestoreStateBeforePatch();
+    const backupPath = backupConfigToml()!;
+    const catalogPath = join(home, '.relay-ai', 'codex', 'app-models-anthropic.json');
+    applyAppConfigPatch(proxySpec(catalogPath), configPath);
+    writeAppSessionLock({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      configPath,
+      catalogPaths: [catalogPath],
+      restoreStatePath: getAppRestoreStatePath(),
+      backupPath,
+      proxyPort: 54321,
+      patchedConfigSha256: fileSha256(configPath),
+      originalConfigSha256: fileSha256(backupPath),
+    });
+
+    expect(restoreCodexAppOverlay().restored).toBe(true);
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+  });
+
+  it('preserves unrelated concurrent config edits instead of overwriting them with the backup', () => {
+    const configPath = getCodexConfigPath();
+    mkdirSync(join(home, '.codex'), { recursive: true });
+    writeFileSync(configPath, 'model = "gpt-5"\nmodel_provider = "openai"\n', 'utf8');
+
+    saveAppRestoreStateBeforePatch();
+    const backupPath = backupConfigToml()!;
+    const catalogPath = join(home, '.relay-ai', 'codex', 'app-models-anthropic.json');
+    applyAppConfigPatch(proxySpec(catalogPath), configPath);
+    const patchedHash = fileSha256(configPath);
+    writeFileSync(configPath, `${readFileSync(configPath, 'utf8')}sandbox = "workspace-write"\n`, 'utf8');
+    writeAppSessionLock({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      configPath,
+      catalogPaths: [catalogPath],
+      restoreStatePath: getAppRestoreStatePath(),
+      backupPath,
+      proxyPort: 54321,
+      patchedConfigSha256: patchedHash,
+      originalConfigSha256: fileSha256(backupPath),
+    });
+
+    expect(restoreCodexAppOverlay().restored).toBe(true);
+    const restored = readFileSync(configPath, 'utf8');
+    expect(restored).toContain('model = "gpt-5"');
+    expect(restored).toContain('sandbox = "workspace-write"');
   });
 });

--- a/tests/codex-app-shutdown.test.ts
+++ b/tests/codex-app-shutdown.test.ts
@@ -5,22 +5,15 @@ const mocks = vi.hoisted(() => ({
   isCancel: vi.fn(() => false),
   isCodexAppRunning: vi.fn(),
   quitCodexAppGracefully: vi.fn(),
-  select: vi.fn(),
-  waitForShutdown: vi.fn(),
 }));
 
 vi.mock('@clack/prompts', () => ({
   confirm: mocks.confirm,
   isCancel: mocks.isCancel,
   log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), step: vi.fn(), success: vi.fn() },
-  select: mocks.select,
+  select: vi.fn(),
   cancel: vi.fn(),
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
-}));
-
-vi.mock('../src/codex/app-session.js', async importOriginal => ({
-  ...(await importOriginal<typeof import('../src/codex/app-session.js')>()),
-  waitForShutdown: mocks.waitForShutdown,
 }));
 
 vi.mock('../src/codex/app-launch.js', () => ({
@@ -31,7 +24,29 @@ vi.mock('../src/codex/app-launch.js', () => ({
   quitCodexAppGracefully: mocks.quitCodexAppGracefully,
 }));
 
-import { maybeCloseRunningCodexApp, waitForShutdownWithConfirm } from '../src/codex-app.js';
+import { codexAppUsesExplicitSelection, maybeCloseRunningCodexApp, unattendedShutdownClosesApp } from '../src/codex-app.js';
+
+describe('unattended Codex App selection', () => {
+  it('honors explicit provider/model flags in non-launching config preview', () => {
+    expect(codexAppUsesExplicitSelection(true, 'antigravity', 'gemini-3.1-pro-high')).toBe(true);
+  });
+
+  it('does not silently accept a partial explicit selection', () => {
+    expect(codexAppUsesExplicitSelection(false, 'antigravity')).toBe(false);
+  });
+});
+
+describe('unattended Codex App shutdown', () => {
+  it('closes the app after SIGTERM/SIGHUP so it cannot retain a dead proxy runtime', () => {
+    expect(unattendedShutdownClosesApp(true, 'sigterm')).toBe(true);
+    expect(unattendedShutdownClosesApp(true, 'sighup')).toBe(true);
+  });
+
+  it('keeps interactive Ctrl+C under the existing confirmation flow', () => {
+    expect(unattendedShutdownClosesApp(true, 'sigint')).toBe(false);
+    expect(unattendedShutdownClosesApp(false, 'sigterm')).toBe(false);
+  });
+});
 
 describe('maybeCloseRunningCodexApp', () => {
   beforeEach(() => {
@@ -56,44 +71,5 @@ describe('maybeCloseRunningCodexApp', () => {
     await maybeCloseRunningCodexApp();
 
     expect(mocks.quitCodexAppGracefully).not.toHaveBeenCalled();
-  });
-
-  it('quits without prompting for an unattended session', async () => {
-    await maybeCloseRunningCodexApp(true);
-
-    expect(mocks.confirm).not.toHaveBeenCalled();
-    expect(mocks.quitCodexAppGracefully).toHaveBeenCalledOnce();
-  });
-});
-
-describe('waitForShutdownWithConfirm', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.isCancel.mockReturnValue(false);
-  });
-
-  it('asks before closing when SIGINT arrives in an interactive session', async () => {
-    mocks.waitForShutdown.mockResolvedValue('sigint');
-    mocks.select.mockResolvedValue('yes');
-
-    await waitForShutdownWithConfirm();
-
-    expect(mocks.select).toHaveBeenCalledOnce();
-  });
-
-  it('returns on SIGINT without prompting for an unattended session', async () => {
-    mocks.waitForShutdown.mockResolvedValue('sigint');
-
-    await waitForShutdownWithConfirm(true);
-
-    expect(mocks.select).not.toHaveBeenCalled();
-  });
-
-  it('never prompts for SIGTERM', async () => {
-    mocks.waitForShutdown.mockResolvedValue('sigterm');
-
-    await waitForShutdownWithConfirm();
-
-    expect(mocks.select).not.toHaveBeenCalled();
   });
 });

--- a/tests/codex-app-shutdown.test.ts
+++ b/tests/codex-app-shutdown.test.ts
@@ -5,15 +5,22 @@ const mocks = vi.hoisted(() => ({
   isCancel: vi.fn(() => false),
   isCodexAppRunning: vi.fn(),
   quitCodexAppGracefully: vi.fn(),
+  select: vi.fn(),
+  waitForShutdown: vi.fn(),
 }));
 
 vi.mock('@clack/prompts', () => ({
   confirm: mocks.confirm,
   isCancel: mocks.isCancel,
   log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), step: vi.fn(), success: vi.fn() },
-  select: vi.fn(),
+  select: mocks.select,
   cancel: vi.fn(),
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+vi.mock('../src/codex/app-session.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/codex/app-session.js')>()),
+  waitForShutdown: mocks.waitForShutdown,
 }));
 
 vi.mock('../src/codex/app-launch.js', () => ({
@@ -24,7 +31,12 @@ vi.mock('../src/codex/app-launch.js', () => ({
   quitCodexAppGracefully: mocks.quitCodexAppGracefully,
 }));
 
-import { codexAppUsesExplicitSelection, maybeCloseRunningCodexApp, unattendedShutdownClosesApp } from '../src/codex-app.js';
+import {
+  codexAppUsesExplicitSelection,
+  maybeCloseRunningCodexApp,
+  unattendedShutdownClosesApp,
+  waitForShutdownWithConfirm,
+} from '../src/codex-app.js';
 
 describe('unattended Codex App selection', () => {
   it('honors explicit provider/model flags in non-launching config preview', () => {
@@ -71,5 +83,44 @@ describe('maybeCloseRunningCodexApp', () => {
     await maybeCloseRunningCodexApp();
 
     expect(mocks.quitCodexAppGracefully).not.toHaveBeenCalled();
+  });
+
+  it('quits without prompting for an unattended session', async () => {
+    await maybeCloseRunningCodexApp(true);
+
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(mocks.quitCodexAppGracefully).toHaveBeenCalledOnce();
+  });
+});
+
+describe('waitForShutdownWithConfirm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isCancel.mockReturnValue(false);
+  });
+
+  it('asks before closing when SIGINT arrives in an interactive session', async () => {
+    mocks.waitForShutdown.mockResolvedValue('sigint');
+    mocks.select.mockResolvedValue('yes');
+
+    await waitForShutdownWithConfirm();
+
+    expect(mocks.select).toHaveBeenCalledOnce();
+  });
+
+  it('returns on SIGINT without prompting for an unattended session', async () => {
+    mocks.waitForShutdown.mockResolvedValue('sigint');
+
+    await waitForShutdownWithConfirm(true);
+
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it('never prompts for SIGTERM', async () => {
+    mocks.waitForShutdown.mockResolvedValue('sigterm');
+
+    await waitForShutdownWithConfirm();
+
+    expect(mocks.select).not.toHaveBeenCalled();
   });
 });

--- a/tests/codex-mixed-launch.test.ts
+++ b/tests/codex-mixed-launch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildCodexMixedLaunchPlan } from '../src/codex/mixed-launch.js';
-import { assertConfiguredCodexSubagentsResolved } from '../src/codex/favorites-launch.js';
+import { assertConfiguredCodexSubagentsResolved, resolveCodexMixedModels } from '../src/codex/favorites-launch.js';
 import { codexLaunchModeOptions } from '../src/codex/prompts.js';
 import type { NativeCodexCatalogSnapshot } from '../src/codex/native-catalog.js';
 import type { ResolvedCodexMixedModels } from '../src/codex/favorites-launch.js';
@@ -13,6 +13,40 @@ const nativeCatalog: NativeCodexCatalogSnapshot = {
 const relay = (providerId: string, id: string) => ({ providerId, providerName: providerId, apiKey: 'key', model: { id, name: id, modelFormat: 'openai', npm: '@ai-sdk/openai-compatible', upstreamModelId: id } }) as never;
 
 describe('Codex mixed launch planning', () => {
+  it('reports a favorite excluded because the selected model consumes a catalog slot', async () => {
+    const models = Array.from({ length: 21 }, (_, index) => ({
+      id: `test-model-${index}`,
+      name: `Test Model ${index}`,
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      upstreamModelId: `test-model-${index}`,
+      contextWindow: 200_000,
+    }));
+    const provider = {
+      id: 'test-provider',
+      name: 'Test Provider',
+      authType: 'none' as const,
+      models,
+    };
+    const favorites = models.slice(1).map(model => ({
+      providerId: provider.id,
+      modelId: model.id,
+    }));
+
+    const result = await resolveCodexMixedModels({
+      activeProvider: provider,
+      selectedModel: models[0]!,
+      compatible: [provider],
+      generalFavorites: favorites,
+      subagentFavorites: [],
+    });
+
+    expect(result.visible).toHaveLength(20);
+    expect(result.capacitySkipped).toEqual([
+      { providerId: provider.id, modelId: 'test-model-20' },
+    ]);
+  });
+
   it('rejects a mixed launch when configured Codex Sub-agents disappear during resolution', () => {
     expect(() => assertConfiguredCodexSubagentsResolved(
       [{ providerId: 'google', modelId: 'gemini-3.5-flash' }],
@@ -51,6 +85,7 @@ describe('Codex mixed launch planning', () => {
         ['google', { id: 'google', name: 'google', models: [subagent.model as never], authType: 'api' } as never],
       ]),
       dropped: [],
+      capacitySkipped: [],
     };
     const plan = buildCodexMixedLaunchPlan({ nativeCatalog, models, multiAgentV2Supported: true });
     expect(plan.nativeModelIds).toEqual(new Set(['gpt-5.5']));
@@ -83,6 +118,7 @@ describe('Codex mixed launch planning', () => {
         ['google', { id: 'google', name: 'google', models: [second.model as never], authType: 'api' } as never],
       ]),
       dropped: [],
+      capacitySkipped: [],
     };
 
     expect(() => buildCodexMixedLaunchPlan({ nativeCatalog, models, multiAgentV2Supported: true }))

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { parse } from 'smol-toml';
 import {
+  applyExternalCodexRuntimeIdentity,
   estimateCodexRequestChars,
   isLikelyCodexCompactionRequest,
   isCodexV2CompactionRequest,
@@ -14,12 +18,46 @@ import { buildCompactionResponseBody, type CodexSdkCallParams } from '../src/cod
 import { CODEX_APP_AUTO_COMPACT_RATIO } from '../src/codex/app-profile.js';
 import { WebSocket, WebSocketServer } from 'ws';
 
+describe('external Codex runtime identity', () => {
+  it('distinguishes the selected external model from the Codex host', () => {
+    const params = applyExternalCodexRuntimeIdentity({
+      system: 'Use the Codex app tools carefully.',
+      messages: [{ role: 'user', content: 'what model are you?' }],
+    }, {
+      modelId: 'antigravity__gemini-3.1-pro-high',
+      providerId: 'antigravity',
+      upstreamModelId: 'gemini-pro-agent',
+      auditUpstreamModelId: 'gemini-3.1-pro-high',
+    });
+
+    expect(params.system).toContain('"gemini-3.1-pro-high" through provider "antigravity"');
+    expect(params.system).toContain('Codex is the host application and agent environment, not the model identity.');
+    expect(params.system).toContain('Use the Codex app tools carefully.');
+    expect(params.system).not.toContain('gemini-pro-agent');
+  });
+
+  it('uses the dynamic upstream model and does not hard-code Gemini', () => {
+    const params = applyExternalCodexRuntimeIdentity({
+      messages: [{ role: 'user', content: 'identify yourself' }],
+    }, {
+      modelId: 'antigravity__claude-sonnet-4-6',
+      providerId: 'antigravity',
+      upstreamModelId: 'claude-sonnet-4-6',
+    });
+
+    expect(params.system).toContain('"claude-sonnet-4-6" through provider "antigravity"');
+    expect(params.system).not.toContain('gemini-3.1-pro-high');
+  });
+});
+
 describe('startCodexProxy', () => {
   let handle: Awaited<ReturnType<typeof startCodexProxy>> | null = null;
+  const auditDirs: string[] = [];
 
   afterEach(() => {
     handle?.close();
     handle = null;
+    for (const dir of auditDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   });
 
   it('serves GET /health', async () => {
@@ -210,8 +248,12 @@ describe('startCodexProxy', () => {
       headers: { 'content-type': 'text/event-stream' },
     }));
     const capability = 'A'.repeat(43);
+    const auditDir = mkdtempSync(join(tmpdir(), 'relay-route-audit-'));
+    auditDirs.push(auditDir);
+    const routeAuditPath = join(auditDir, 'route-audit.jsonl');
     handle = await startCodexProxy([], {
       requireAuth: false,
+      routeAuditPath,
       mixedNative: { nativeModelIds: new Set(['gpt-5.5']), capability, nativeFetchImpl: nativeFetch as typeof fetch },
     });
     try {
@@ -236,6 +278,17 @@ describe('startCodexProxy', () => {
       const init = nativeFetch.mock.calls[0]![1] as RequestInit;
       expect(init.headers).toEqual(expect.objectContaining({ authorization: 'Bearer native', 'ChatGPT-Account-Id': 'acct' }));
       expect(JSON.stringify(init.headers)).not.toContain('relay-secret');
+
+      const auditText = readFileSync(routeAuditPath, 'utf8');
+      const auditEvents = auditText.trim().split('\n').map(line => JSON.parse(line) as Record<string, unknown>);
+      expect(auditEvents).toEqual(expect.arrayContaining([
+        expect.objectContaining({ dispatch: 'native', phase: 'dispatch', requestedModel: 'gpt-5.5', provider: 'openai-native' }),
+        expect.objectContaining({ dispatch: 'native', phase: 'complete', requestedModel: 'gpt-5.5', outcome: 'ok', status: 200 }),
+      ]));
+      expect(auditText).not.toContain('hi');
+      expect(auditText).not.toContain('Bearer');
+      expect(auditText).not.toContain('relay-secret');
+      expect(statSync(routeAuditPath).mode & 0o777).toBe(0o600);
 
       const unknown = await fetch(`http://127.0.0.1:${handle.port}/_relay-codex/${capability}/v1/responses`, {
         method: 'POST',
@@ -379,15 +432,20 @@ describe('startCodexProxy', () => {
     const providerPort = await new Promise<number>(resolve => provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port)));
 
     const capability = 'E'.repeat(43);
+    const auditDir = mkdtempSync(join(tmpdir(), 'relay-route-audit-'));
+    auditDirs.push(auditDir);
+    const routeAuditPath = join(auditDir, 'route-audit.jsonl');
     handle = await startCodexProxy([{
       modelId: 'provider__child',
       npm: '@ai-sdk/openai-compatible',
       apiKey: 'test-key',
       baseURL: `http://127.0.0.1:${providerPort}/v1`,
       upstreamModelId: 'child-model',
+      auditUpstreamModelId: 'provider-facing-child-model',
       providerId: 'provider',
     }], {
       requireAuth: false,
+      routeAuditPath,
       mixedNative: {
         nativeModelIds: new Set(['gpt-5.6-luna']),
         subagentRouteModelId: 'provider__child',
@@ -427,6 +485,12 @@ describe('startCodexProxy', () => {
 
       expect(JSON.stringify(providerBody)).toContain('DELEGATED_MARKER');
       expect(JSON.stringify(providerBody)).not.toContain(`gAAAAA${'A'.repeat(40)}`);
+      const routeAudit = readFileSync(routeAuditPath, 'utf8');
+      expect(routeAudit).toContain('"dispatch":"relay-subagent"');
+      expect(routeAudit).toContain('"provider":"provider"');
+      expect(routeAudit).toContain('"upstreamModel":"provider-facing-child-model"');
+      expect(routeAudit).not.toContain('DELEGATED_MARKER');
+      expect(routeAudit).not.toContain('encrypted_content');
     } finally {
       await new Promise<void>(resolve => nativeRelay.close(() => resolve()));
       await new Promise<void>(resolve => provider.close(() => resolve()));

--- a/tests/codex-route-audit.test.ts
+++ b/tests/codex-route-audit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendCodexRouteAudit,
+  prepareCodexRouteAuditLog,
+  sanitizeCodexRouteAuditEvent,
+} from '../src/codex/route-audit.js';
+
+describe('Codex route audit', () => {
+  it('writes only bounded routing metadata to a private JSONL receipt', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'relay-route-audit-'));
+    try {
+      const path = prepareCodexRouteAuditLog(join(dir, 'audit.jsonl'));
+      appendCodexRouteAudit(path, {
+        transport: 'ws',
+        requestedModel: `antigravity__gemini-3.1-pro-high\nforged=${'x'.repeat(500)}`,
+        dispatch: 'relay',
+        phase: 'complete',
+        provider: 'antigravity',
+        routeModel: 'antigravity__gemini-3.1-pro-high',
+        upstreamModel: 'gemini-3.1-pro-high',
+        outcome: 'ok',
+        status: 'response.completed',
+      });
+
+      const text = readFileSync(path, 'utf8');
+      const event = JSON.parse(text) as Record<string, unknown>;
+      expect(event).toMatchObject({
+        transport: 'ws', dispatch: 'relay', phase: 'complete', provider: 'antigravity',
+        upstreamModel: 'gemini-3.1-pro-high', outcome: 'ok', status: 'response.completed',
+      });
+      expect(String(event.requestedModel)).not.toContain('\n');
+      expect(String(event.requestedModel).length).toBeLessThanOrEqual(300);
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+      expect(text).not.toContain('authorization');
+      expect(text).not.toContain('input');
+      expect(text).not.toContain('tools');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits absent optional fields', () => {
+    const event = sanitizeCodexRouteAuditEvent({
+      transport: 'http', requestedModel: 'unknown', dispatch: 'unknown', phase: 'complete', outcome: 'error', status: 404,
+    });
+    expect(event).not.toHaveProperty('provider');
+    expect(event).not.toHaveProperty('routeModel');
+    expect(event).not.toHaveProperty('upstreamModel');
+  });
+});

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -70,7 +70,7 @@ describe('parseProvidersArgs', () => {
     expect(help).toContain('providers remove');
     expect(help).toContain('refresh-models');
     expect(help).toContain('Phase 1.1');
-    for (const template of PROVIDER_TEMPLATES.filter(t => t.hidden)) {
+    for (const template of PROVIDER_TEMPLATES.filter(t => t.hidden && t.id !== 'antigravity')) {
       expect(help).not.toContain(template.id);
       expect(help).not.toContain(template.name);
     }
@@ -81,7 +81,8 @@ describe('parseProvidersArgs', () => {
     expect(help).toContain('github-copilot');
     expect(help).toContain('openai-oauth');
     expect(help).toContain('xai-oauth');
-    for (const template of PROVIDER_TEMPLATES.filter(t => t.hidden)) {
+    expect(help).toContain('antigravity');
+    for (const template of PROVIDER_TEMPLATES.filter(t => t.hidden && t.id !== 'antigravity')) {
       expect(help).not.toContain(template.id);
       expect(help).not.toContain(template.name);
     }


### PR DESCRIPTION
## What changed

- **Startup readiness probe (`app-readiness.ts`):** Verify proxy `/health`, models catalog, and temporary `config.toml` readback before launching/restarting ChatGPT Desktop, eliminating the race where the UI loaded before Relay's proxy was listening.
- **External model runtime identity (`codex-proxy.ts`):** Add `applyExternalCodexRuntimeIdentity` to inject a targeted `<external-model-identity>` block at the proxy dispatch boundary. This ensures Gemini, Claude, and OSS models know their identity without getting confused by Codex's host `role: 'developer'` prompt while preserving all host tool instructions.
- **macOS process lifecycle hardening (`app-launch.ts`):** Track full Darwin app bundle PIDs (`com.openai.codex`), expand graceful quit timeout to 30s for live Codex task settling, and detect login-item auto-relaunch without opening duplicate processes.
- **Metadata-only route audit log (`route-audit.ts`):** Record request routing receipts (timestamp, transport, requested model, provider, route model, upstream model, status) to `~/.relay-ai/logs/codex-route-audit.jsonl` with `0600` permissions, never recording prompts, tokens, headers, or credentials.
- **Config & session hash binding (`app-session.ts`, `app-config.ts`):** Validate exact sha256 checksums before restoring config files to prevent clobbering concurrent user edits.
- **Test portability (`antigravity-launch-ide.test.ts`):** Skip optional GUI binary assertions when only the Antigravity CLI is installed.

## Why

1. **Startup race:** On macOS, ChatGPT occasionally launched before the proxy port was fully bound, leaving the app unresponsive until restarted.
2. **Runtime identity confusion:** Even after static catalog sanitization (#50), Codex dynamically injects `role: 'developer'` system prompts containing `You are Codex...` on every conversation turn. External models like Gemini then claimed to be GPT/Codex.
3. **Electron helper cleanup:** On macOS, quitting the main window can leave Electron helpers running, causing subsequent launches to fail or race.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm test -- --run` (156 test files passed, 1,673 unit tests passed, 0 failures)
- Live macOS end-to-end verification:
  - Startup readiness probe verified against random capability-protected proxy port
  - Same-task switching verified in ChatGPT Desktop: native GPT-5.6 Sol → Gemini 3.1 Pro High → GPT-5.6 Sol
  - Provider routes confirmed via metadata route audit: `openai-native` vs `antigravity` (`gemini-pro-agent`)
  - External model identity verified: Gemini identifies as Google Gemini hosted inside Codex rather than OpenAI GPT
  - Graceful shutdown and config restoration verified