### PR TITLE
fix(codex): keep Relay Responses WebSockets open across turns

### DIFF
--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -984,7 +984,7 @@ export async function startCodexProxy(
       );
 
       let frameBuf = Buffer.alloc(0);
-      let handled = false;
+      let externalInFlight = false;
       let nativeActive = false;
       let nativeUpstream: WebSocket | undefined;
       // Set once the request body is parsed, below — sendWsEvent is defined before
@@ -1019,10 +1019,6 @@ export async function startCodexProxy(
 
       const onData = (chunk: Buffer) => {
         frameBuf = Buffer.concat([frameBuf, chunk]);
-        // Native Codex keeps one Responses WebSocket open across turns. Relay
-        // routes still use the original one-request guard, but native frames
-        // must continue through the established upstream connection.
-        if (handled && !nativeActive) return;
         const frame = wsDecodeFrame(frameBuf);
         if (!frame) return;
         frameBuf = Buffer.alloc(0);
@@ -1044,7 +1040,14 @@ export async function startCodexProxy(
           socket.end();
           return;
         }
-        handled = true;
+        // Responses WebSockets are persistent across turns. Native requests
+        // already stream through one upstream socket; external Relay requests
+        // run sequentially on the downstream connection because their SDK
+        // adapter owns one provider stream at a time.
+        if (externalInFlight) {
+          closeSocket(1008);
+          return;
+        }
 
         void (async () => {
           let body: Record<string, unknown>;
@@ -1255,6 +1258,7 @@ export async function startCodexProxy(
             provider: route.providerId ?? 'relay', routeModel: route.modelId,
             upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
           });
+          externalInFlight = true;
           try {
             const routedBody = await prepareExternalCodexBody(body, {
               relay: nativePayloadRelay,
@@ -1325,8 +1329,9 @@ export async function startCodexProxy(
             } else {
               writeResponsesErrorStream(modelId, msg, sendWsEvent, status);
             }
+          } finally {
+            externalInFlight = false;
           }
-          closeSocket();
         })();
       };
 

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -18,6 +18,27 @@ import { buildCompactionResponseBody, type CodexSdkCallParams } from '../src/cod
 import { CODEX_APP_AUTO_COMPACT_RATIO } from '../src/codex/app-profile.js';
 import { WebSocket, WebSocketServer } from 'ws';
 
+function openAiCompatibleTextStream(id: string, text: string, created: number): string {
+  return [
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'relay-upstream',
+      choices: [{ index: 0, delta: { role: 'assistant', content: text }, finish_reason: null }],
+    })}`,
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'relay-upstream',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    })}`,
+    'data: [DONE]',
+    '',
+  ].join('\n\n');
+}
+
 describe('external Codex runtime identity', () => {
   it('distinguishes the selected external model from the Codex host', () => {
     const params = applyExternalCodexRuntimeIdentity({
@@ -397,6 +418,119 @@ describe('startCodexProxy', () => {
       expect(received[1]).toMatchObject({ type: 'response.create', input: 'second' });
     } finally {
       await new Promise<void>(resolve => upstream.close(() => resolve()));
+    }
+  });
+
+  it('keeps a Relay WebSocket open for multiple response.create turns', async () => {
+    let providerCalls = 0;
+    const provider = createServer((req, res) => {
+      req.resume();
+      req.once('end', () => {
+        providerCalls += 1;
+        const responseId = `chatcmpl-${providerCalls}`;
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end(openAiCompatibleTextStream(responseId, `turn-${providerCalls}`, providerCalls));
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => {
+      provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port));
+    });
+
+    handle = await startCodexProxy([{
+      modelId: 'provider__relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-upstream',
+      providerId: 'provider',
+    }], { requireAuth: false });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/v1/responses`);
+        const timer = setTimeout(() => {
+          client.close();
+          reject(new Error('timed out waiting for the second Relay turn'));
+        }, 5000);
+        let responseCount = 0;
+        client.on('open', () => {
+          client.send(JSON.stringify({ model: 'provider__relay-model', input: 'first', stream: true }));
+        });
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as { type?: string };
+          if (event.type !== 'response.completed') return;
+          responseCount += 1;
+          if (responseCount === 1) {
+            client.send(JSON.stringify({ model: 'provider__relay-model', input: 'second', stream: true }));
+          } else {
+            client.close();
+          }
+        });
+        client.on('close', () => {
+          clearTimeout(timer);
+          if (responseCount === 2) resolve();
+          else reject(new Error(`Relay closed after ${responseCount} completed response(s)`));
+        });
+        client.on('error', reject);
+      });
+      expect(providerCalls).toBe(2);
+    } finally {
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
+  it('rejects overlapping Relay WebSocket turns without duplicating provider work', async () => {
+    let providerCalls = 0;
+    let markProviderCalled!: () => void;
+    const providerCalled = new Promise<void>(resolve => { markProviderCalled = resolve; });
+    const provider = createServer((req, res) => {
+      req.resume();
+      req.once('end', () => {
+        providerCalls += 1;
+        markProviderCalled();
+        setTimeout(() => {
+          res.writeHead(200, { 'content-type': 'text/event-stream' });
+          res.end(openAiCompatibleTextStream('chatcmpl-overlap', 'first', 1));
+        }, 100);
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => {
+      provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port));
+    });
+
+    handle = await startCodexProxy([{
+      modelId: 'provider__relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-upstream',
+      providerId: 'provider',
+    }], { requireAuth: false });
+
+    try {
+      const closeCode = await new Promise<number>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/v1/responses`);
+        const timer = setTimeout(() => {
+          client.close();
+          reject(new Error('timed out waiting for overlapping Relay turn rejection'));
+        }, 5000);
+        client.on('open', () => {
+          client.send(JSON.stringify({ model: 'provider__relay-model', input: 'first', stream: true }));
+          void providerCalled.then(() => {
+            client.send(JSON.stringify({ model: 'provider__relay-model', input: 'overlap', stream: true }));
+          });
+        });
+        client.on('close', code => {
+          clearTimeout(timer);
+          resolve(code);
+        });
+        client.on('error', reject);
+      });
+      await providerCalled;
+      expect(closeCode).toBe(1008);
+      expect(providerCalls).toBe(1);
+    } finally {
+      await new Promise<void>(resolve => provider.close(() => resolve()));
     }
   });
 


### PR DESCRIPTION
## What changed?

- keep external Relay Responses WebSockets open after terminal response events
- accept sequential `response.create` frames on the same downstream connection
- reject overlapping external turns with WebSocket policy code `1008` before a second provider request can start
- preserve the existing persistent native OpenAI bridge, ping/pong handling, client-driven closure, authentication, and model routing

## Root cause

Relay treated external Responses WebSockets as one request per connection and sent a normal close frame immediately after `response.completed`. ChatGPT desktop build `26.818.21641` bundles Codex `0.148.0-alpha.21`, whose Responses client keeps one WebSocket open across turns. It interpreted Relay's post-completion close as a disconnected stream and repeated the sampling request, causing duplicate provider work even though the first request completed successfully.

## Scope

- [x] This PR contains one focused fix: persistent downstream Responses WebSockets for external Relay routes.
- [x] The implementation branch starts from current canonical `main` at `c084f02`, including merged PR #53 and JB's unattended-shutdown correction.
- [x] The change is below the maintainer-discussion size threshold.
- [x] Unrelated PR #53 startup, identity, audit, restoration, lifecycle, preview, capacity, auth-help, and portability changes are excluded.
- [x] Generated `dist` files and dependency files are excluded.

Closes #55. The issue was opened before PR publication as required by Relay's contribution guide for proxy/networking lifecycle changes.

## Reproduction

1. Launch ChatGPT desktop through Relay with an external model.
2. Submit a simple prompt through Codex `0.148.0-alpha.21`.
3. Relay emits a successful `response.completed` event and closes the downstream WebSocket.
4. Codex reports `stream disconnected - retrying sampling request` and sends the request again.

The frozen regression test against upstream `v0.9.5` failed with:

```text
Relay closed after 1 completed response(s)
```

## User impact

External Codex turns no longer retry solely because Relay closed an otherwise successful Responses stream. A persistent connection can carry later turns and tool-loop sampling steps without duplicating provider work at the transport boundary.

## Validation

- [x] Focused tests added: proxy suite `43 passed`.
- [x] Overlap regression passed five consecutive isolated runs.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes: `1,679 passed`, `8 skipped`, zero failures.
- [x] `npm run build` passes.
- [x] No user-facing documentation change is needed; the correct behavior is transparent transport compatibility.
- [x] No screenshot is needed because there is no visible UI change.
- [x] Unchanged upstream `c084f02` baseline established: `1,677 passed`, `8 skipped`, zero failures.
- [x] Isolated `npm pack` installation reported Relay `0.9.5`.
- [x] Integration with the merged macOS hardening: `45` proxy tests passed, typecheck passed, production build passed, and the full suite remained green.
- [x] Live macOS test with ChatGPT build `26.818.21641` and Codex `0.148.0-alpha.21`: one WebSocket carried two deliberate Gemini turns, each with one dispatch and one completion, then closed normally with code `1000`.
- [x] The Codex marker reproduction no longer emitted `responses_retry` or `stream disconnected`.
- [x] The same recorded session switched from Gemini to native GPT-5.6 Sol and returned the exact requested marker through the native route.

## Risks and limitations

The change does not alter request bodies, provider credentials, model selection, native forwarding, or response translation. External requests remain sequential because the SDK adapter owns one provider stream at a time. If a client overlaps external turns, Relay closes the connection with policy code `1008` and the regression test verifies that only the first provider request starts.

## Deliberate non-goals

- no PR #53 startup, identity, audit, restoration, or lifecycle changes
- no native Responses WebSocket changes
- no generated `dist` artifacts in the source PR unless the maintainer requests them
- no attempt to repair the separately observed empty post-tool continuation; that requires its own reproduction and single-issue review
