### PR TITLE
fix(codex-proxy): keep external WebSocket turns persistent

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -4592,18 +4592,19 @@ Sec-WebSocket-Accept: ${wsAcceptKey(clientKey)}\r
 `
       );
       let frameBuf = Buffer.alloc(0);
-      let handled = false;
+      let externalActive = false;
       let nativeActive = false;
       let nativeUpstream;
+      let socketClosing = false;
       let currentRequestModel = "";
       const closeSocket = (code = 1e3) => {
-        if (!socket.destroyed) {
-          socket.write(wsCloseFrame(code));
-          socket.end();
-        }
+        if (socketClosing || socket.destroyed) return;
+        socketClosing = true;
+        socket.write(wsCloseFrame(code));
+        socket.end();
       };
       const sendWsEvent = (sseChunk2) => {
-        if (socket.destroyed) return;
+        if (socketClosing || socket.destroyed) return;
         if (debug) {
           const completed = captureCompletedResponse(sseChunk2);
           if (completed) {
@@ -4624,7 +4625,6 @@ Sec-WebSocket-Accept: ${wsAcceptKey(clientKey)}\r
       };
       const onData = (chunk) => {
         frameBuf = Buffer.concat([frameBuf, chunk]);
-        if (handled && !nativeActive) return;
         const frame = wsDecodeFrame(frameBuf);
         if (!frame) return;
         frameBuf = Buffer.alloc(0);
@@ -4646,7 +4646,10 @@ Sec-WebSocket-Accept: ${wsAcceptKey(clientKey)}\r
           socket.end();
           return;
         }
-        handled = true;
+        if (externalActive) {
+          closeSocket(1008);
+          return;
+        }
         void (async () => {
           let body;
           try {
@@ -4858,6 +4861,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
               }
             }
           }
+          externalActive = true;
           let resolved = subagentRoute ? resolveModel(routes, models, subagentRoute.modelId) : resolveModel(routes, models, modelId);
           if (!resolved) {
             const fb = routes[0];
@@ -4969,7 +4973,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
               writeResponsesErrorStream(modelId, msg, sendWsEvent, status);
             }
           }
-          closeSocket();
+          externalActive = false;
         })();
       };
       socket.on("error", () => socket.destroy());

--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -984,19 +984,23 @@ export async function startCodexProxy(
       );
 
       let frameBuf = Buffer.alloc(0);
-      let handled = false;
+      let externalActive = false;
       let nativeActive = false;
       let nativeUpstream: WebSocket | undefined;
+      let socketClosing = false;
       // Set once the request body is parsed, below — sendWsEvent is defined before
       // that point but needs the model id for its own debug dump.
       let currentRequestModel = '';
 
       const closeSocket = (code = 1000) => {
-        if (!socket.destroyed) { socket.write(wsCloseFrame(code)); socket.end(); }
+        if (socketClosing || socket.destroyed) return;
+        socketClosing = true;
+        socket.write(wsCloseFrame(code));
+        socket.end();
       };
 
       const sendWsEvent = (sseChunk: string) => {
-        if (socket.destroyed) return;
+        if (socketClosing || socket.destroyed) return;
         if (debug) {
           const completed = captureCompletedResponse(sseChunk);
           if (completed) {
@@ -1019,10 +1023,6 @@ export async function startCodexProxy(
 
       const onData = (chunk: Buffer) => {
         frameBuf = Buffer.concat([frameBuf, chunk]);
-        // Native Codex keeps one Responses WebSocket open across turns. Relay
-        // routes still use the original one-request guard, but native frames
-        // must continue through the established upstream connection.
-        if (handled && !nativeActive) return;
         const frame = wsDecodeFrame(frameBuf);
         if (!frame) return;
         frameBuf = Buffer.alloc(0);
@@ -1044,7 +1044,13 @@ export async function startCodexProxy(
           socket.end();
           return;
         }
-        handled = true;
+        if (externalActive) {
+          // The external SDK stream cannot safely multiplex turns. Closing with
+          // policy violation makes the client fail closed instead of starting a
+          // second provider request that could be retried or double-billed.
+          closeSocket(1008);
+          return;
+        }
 
         void (async () => {
           let body: Record<string, unknown>;
@@ -1233,6 +1239,7 @@ export async function startCodexProxy(
               }
             }
           }
+          externalActive = true;
           let resolved = subagentRoute
             ? resolveModel(routes, models, subagentRoute.modelId)
             : resolveModel(routes, models, modelId);
@@ -1326,7 +1333,7 @@ export async function startCodexProxy(
               writeResponsesErrorStream(modelId, msg, sendWsEvent, status);
             }
           }
-          closeSocket();
+          externalActive = false;
         })();
       };
 

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -400,6 +400,130 @@ describe('startCodexProxy', () => {
     }
   });
 
+  it('keeps an external WebSocket open for sequential response.create turns', async () => {
+    const requestBodies: Record<string, unknown>[] = [];
+    const provider = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.once('end', () => {
+        requestBodies.push(JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>);
+        const turn = requestBodies.length;
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.write(`data: ${JSON.stringify({
+          id: `chatcmpl-${turn}`,
+          object: 'chat.completion.chunk',
+          choices: [{ index: 0, delta: { role: 'assistant', content: `turn-${turn}` }, finish_reason: null }],
+        })}\n\n`);
+        res.write(`data: ${JSON.stringify({
+          id: `chatcmpl-${turn}`,
+          object: 'chat.completion.chunk',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        })}\n\n`);
+        res.end('data: [DONE]\n\n');
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port)));
+    const capability = 'F'.repeat(43);
+    handle = await startCodexProxy([{
+      modelId: 'relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-model',
+      providerId: 'relay-provider',
+    }], {
+      requireAuth: false,
+      mixedNative: { nativeModelIds: new Set(['gpt-5.5']), capability },
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`);
+        const timer = setTimeout(() => { client.close(); reject(new Error('timed out waiting for the second external turn')); }, 3_000);
+        let completed = 0;
+        client.on('open', () => client.send(JSON.stringify({ model: 'relay-model', input: 'first' })));
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as { type?: string };
+          if (event.type !== 'response.completed') return;
+          completed += 1;
+          if (completed === 1) client.send(JSON.stringify({ model: 'relay-model', input: 'second' }));
+          if (completed === 2) client.close();
+        });
+        client.on('close', code => {
+          clearTimeout(timer);
+          if (code !== 1000 || completed !== 2) {
+            reject(new Error(`external socket closed before two turns completed: code=${code} completed=${completed}`));
+            return;
+          }
+          resolve();
+        });
+        client.on('error', reject);
+      });
+      expect(requestBodies).toHaveLength(2);
+      expect(JSON.stringify(requestBodies[0])).toContain('first');
+      expect(JSON.stringify(requestBodies[1])).toContain('second');
+    } finally {
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
+  it('closes an external WebSocket with policy code when a turn overlaps an active provider request', async () => {
+    let providerCalls = 0;
+    let firstRequest!: () => void;
+    const firstRequestSeen = new Promise<void>(resolve => { firstRequest = resolve; });
+    let releaseFirst!: () => void;
+    const firstResponseReleased = new Promise<void>(resolve => { releaseFirst = resolve; });
+    const provider = createServer((req, res) => {
+      req.resume();
+      req.once('end', () => {
+        providerCalls += 1;
+        if (providerCalls !== 1) {
+          res.writeHead(500);
+          res.end();
+          return;
+        }
+        firstRequest();
+        void firstResponseReleased.then(() => {
+          res.writeHead(200, { 'content-type': 'text/event-stream' });
+          res.end(`data: ${JSON.stringify({
+            id: 'chatcmpl-1',
+            object: 'chat.completion.chunk',
+            choices: [{ index: 0, delta: { content: 'first' }, finish_reason: 'stop' }],
+          })}\n\ndata: [DONE]\n\n`);
+        });
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port)));
+    const capability = 'G'.repeat(43);
+    handle = await startCodexProxy([{
+      modelId: 'relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-model',
+      providerId: 'relay-provider',
+    }], {
+      requireAuth: false,
+      mixedNative: { nativeModelIds: new Set(['gpt-5.5']), capability },
+    });
+
+    try {
+      const closeCode = await new Promise<number>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`);
+        const timer = setTimeout(() => { client.close(); reject(new Error('timed out waiting for overlap rejection')); }, 3_000);
+        client.on('open', () => client.send(JSON.stringify({ model: 'relay-model', input: 'first' })));
+        void firstRequestSeen.then(() => client.send(JSON.stringify({ model: 'relay-model', input: 'second' })));
+        client.on('close', code => { clearTimeout(timer); resolve(code); });
+        client.on('error', reject);
+      });
+      expect(closeCode).toBe(1008);
+      expect(providerCalls).toBe(1);
+    } finally {
+      releaseFirst();
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
   it('resolves a WebSocket child payload before contacting the Relay model', async () => {
     const nativeRelay = createServer((req, res) => {
       req.resume();


### PR DESCRIPTION
## Summary
- keep external Relay Responses WebSockets open across sequential `response.create` turns
- reject overlapping external turns with WebSocket policy close `1008` before a second provider request
- preserve native forwarding, ping/pong, authentication, and explicit client close handling

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #55
