### PR TITLE
fix(codex): reset native WebSocket state for each turn

### DIFF
--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -987,6 +987,7 @@ export async function startCodexProxy(
       let externalActive = false;
       let nativeActive = false;
       let nativeUpstream: WebSocket | undefined;
+      let sendNativeTurn: ((body: Record<string, unknown>) => void) | undefined;
       let socketClosing = false;
       // Set once the request body is parsed, below — sendWsEvent is defined before
       // that point but needs the model id for its own debug dump.
@@ -1121,9 +1122,9 @@ export async function startCodexProxy(
                   log(`WS native history normalized: model=${modelId} converted Relay compaction for native verification`);
                 }
                 if (nativeActive && nativeUpstream) {
-                  if (nativeUpstream.readyState === WebSocket.OPEN) {
+                  if (nativeUpstream.readyState === WebSocket.OPEN && sendNativeTurn) {
                     if (debug) log(`WS native forwarding next turn: model=${modelId}`);
-                    nativeUpstream.send(JSON.stringify({ type: 'response.create', ...nativeBody }));
+                    sendNativeTurn(nativeBody);
                   } else if (debug) {
                     log(`WS native cannot forward next turn: upstream_state=${nativeUpstream.readyState}`);
                   }
@@ -1171,6 +1172,12 @@ export async function startCodexProxy(
                   try { upstream?.close(); } catch { /* ignore */ }
                   closeSocket(closeCode);
                 };
+                const beginNativeTurn = (turnBody: Record<string, unknown>) => {
+                  nativeCompleted = false;
+                  if (firstFrameTimer) clearTimeout(firstFrameTimer);
+                  upstream?.send(JSON.stringify({ type: 'response.create', ...turnBody }));
+                  firstFrameTimer = setTimeout(() => closeBoth('Native Codex WebSocket response timed out'), 60_000);
+                };
                 try {
                   if (debug) {
                     log(`WS native connecting: model=${modelId} url=${target.url} headers=[${Object.keys(target.headers).join(',')}]`);
@@ -1183,8 +1190,8 @@ export async function startCodexProxy(
                     nativeOpened = true;
                     if (connectTimer) clearTimeout(connectTimer);
                     if (debug) log(`WS native upstream open: model=${modelId}`);
-                    upstream?.send(JSON.stringify({ type: 'response.create', ...nativeBody }));
-                    firstFrameTimer = setTimeout(() => closeBoth('Native Codex WebSocket response timed out'), 60_000);
+                    sendNativeTurn = beginNativeTurn;
+                    beginNativeTurn(nativeBody);
                   });
                   upstream.once('unexpected-response', (_request, response) => {
                     if (debug) log(`WS native upstream HTTP rejection: model=${modelId} status=${response.statusCode}`);
@@ -1221,6 +1228,7 @@ export async function startCodexProxy(
                     const detail = reason?.length ? ` reason=${reason.toString('utf8').slice(0, 200)}` : '';
                     if (debug) log(`WS native upstream close: model=${modelId} code=${code}${detail} frames=${nativeFrameCount}`);
                     if (nativeUpstream === upstream) nativeUpstream = undefined;
+                    if (sendNativeTurn === beginNativeTurn) sendNativeTurn = undefined;
                     nativeActive = false;
                     if (!finished) closeBoth(nativeCompleted ? undefined : `Native Codex WebSocket closed before completion (${code})`);
                   });
@@ -1229,6 +1237,7 @@ export async function startCodexProxy(
                     finished = true;
                     nativeActive = false;
                     if (nativeUpstream === upstream) nativeUpstream = undefined;
+                    if (sendNativeTurn === beginNativeTurn) sendNativeTurn = undefined;
                     clearTimers();
                     try { upstream?.close(); } catch { /* ignore */ }
                   });

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -400,6 +400,73 @@ describe('startCodexProxy', () => {
     }
   });
 
+  it('reports a later native WebSocket turn that closes before completion', async () => {
+    const upstream = new WebSocketServer({ port: 0 });
+    const upstreamPort = await new Promise<number>(resolve => {
+      upstream.on('listening', () => resolve((upstream.address() as { port: number }).port));
+    });
+    let requestCount = 0;
+    upstream.on('connection', socket => {
+      socket.on('message', () => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          socket.send(JSON.stringify({ type: 'response.completed', response: { status: 'completed' } }));
+        } else {
+          socket.close(1011, 'second turn failed');
+        }
+      });
+    });
+    const capability = 'N'.repeat(43);
+    handle = await startCodexProxy([], {
+      requireAuth: false,
+      mixedNative: {
+        nativeModelIds: new Set(['gpt-5.5']),
+        capability,
+        nativeBaseUrl: `http://127.0.0.1:${upstreamPort}`,
+      },
+    });
+
+    try {
+      const result = await new Promise<{ closeCode: number; errors: string[] }>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`);
+        const errors: string[] = [];
+        const timer = setTimeout(() => {
+          client.close();
+          reject(new Error('timed out waiting for failed second native turn'));
+        }, 5000);
+        let completed = 0;
+        client.on('open', () => {
+          client.send(JSON.stringify({ model: 'gpt-5.5', input: 'first' }));
+        });
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as {
+            type?: string;
+            error?: { message?: string };
+          };
+          if (event.type === 'response.completed') {
+            completed += 1;
+            if (completed === 1) client.send(JSON.stringify({ model: 'gpt-5.5', input: 'second' }));
+          } else if (event.type === 'error' && event.error?.message) {
+            errors.push(event.error.message);
+          }
+        });
+        client.on('close', closeCode => {
+          clearTimeout(timer);
+          resolve({ closeCode, errors });
+        });
+        client.on('error', reject);
+      });
+
+      expect(requestCount).toBe(2);
+      expect(result.closeCode).toBe(1011);
+      expect(result.errors).toEqual([
+        'Native Codex WebSocket closed before completion (1011)',
+      ]);
+    } finally {
+      await new Promise<void>(resolve => upstream.close(() => resolve()));
+    }
+  });
+
   it('keeps an external WebSocket open for sequential response.create turns', async () => {
     const requestBodies: Record<string, unknown>[] = [];
     const provider = createServer((req, res) => {


### PR DESCRIPTION
## What changed?

Relay now starts every native `response.create` through one connection-scoped turn sender. First and later turns both reset completion state, rearm the first-frame timeout, and send through the existing upstream WebSocket.

The sender is cleared with the native connection, so no later downstream frame can target a closed upstream turn closure.

## Scope

- [x] One focused fix: per-turn state for the persistent native Responses WebSocket.
- [x] Based on current upstream `main` at `881cac4`, including JB's external WebSocket persistence implementation.
- [x] Below the maintainer-discussion size threshold.
- [x] External Relay routes, response translation, credentials, model routing, dependencies, UI, and generated `dist` files are excluded.
- [x] A focused networking issue will be linked before PR publication.

Closes #59.

Intended files:

- `src/codex-proxy.ts`
- `tests/codex-proxy.test.ts`

## Validation

- [x] Frozen red test reproduced the stale completion state.
- [x] Focused proxy suite: `44 passed`.
- [x] `npm run typecheck` passes.
- [x] Full suite: `1,680 passed`, `8 skipped`, zero failures.
- [x] `npm run build` passes.
- [x] Existing successful two-turn native test remains green.
- [x] No user-facing documentation or screenshot is required.

## Risks and limitations

- The existing 60-second timer remains a first-frame timeout, not a full-stream idle timeout.
- Later native turns still require the upstream socket to be open before forwarding.
- This PR does not queue frames received while the native upstream is still connecting.
- External model WebSocket lifecycle and `previous_response_id` state are separate issues.
