### PR TITLE
fix(codex): restore external tool continuation context

### DIFF
--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -58,6 +58,38 @@ function captureCompletedResponse(sseText: string): unknown | undefined {
   return undefined;
 }
 
+const MAX_EXTERNAL_RESPONSE_STATES_PER_SOCKET = 8;
+
+function responsesInputItems(input: unknown): unknown[] {
+  if (Array.isArray(input)) return input;
+  if (typeof input === 'string') return [{ role: 'user', content: input }];
+  return [];
+}
+
+function responsesInputNeedsPreviousState(input: unknown): boolean {
+  if (!Array.isArray(input)) return false;
+  const callIds = new Set<string>();
+  for (const item of input) {
+    if (!item || typeof item !== 'object') continue;
+    const record = item as { type?: unknown; call_id?: unknown };
+    if (
+      typeof record.type === 'string'
+      && record.type.endsWith('_call')
+      && typeof record.call_id === 'string'
+    ) {
+      callIds.add(record.call_id);
+    }
+  }
+  return input.some(item => {
+    if (!item || typeof item !== 'object') return false;
+    const record = item as { type?: unknown; call_id?: unknown };
+    return typeof record.type === 'string'
+      && record.type.endsWith('_call_output')
+      && typeof record.call_id === 'string'
+      && !callIds.has(record.call_id);
+  });
+}
+
 export function estimateCodexRequestChars(params: CodexSdkCallParams): number {
   let chars = (params.system ?? '').length;
   for (const msg of params.messages) {
@@ -987,6 +1019,15 @@ export async function startCodexProxy(
       let externalActive = false;
       let nativeActive = false;
       let nativeUpstream: WebSocket | undefined;
+      const externalResponseStates = new Map<string, unknown[]>();
+      const completedExternalResponse: {
+        current?: {
+          id?: unknown;
+          status?: unknown;
+          output?: unknown;
+        };
+      } = {};
+      const readCompletedExternalResponse = () => completedExternalResponse.current;
       let socketClosing = false;
       // Set once the request body is parsed, below — sendWsEvent is defined before
       // that point but needs the model id for its own debug dump.
@@ -1001,9 +1042,10 @@ export async function startCodexProxy(
 
       const sendWsEvent = (sseChunk: string) => {
         if (socketClosing || socket.destroyed) return;
-        if (debug) {
-          const completed = captureCompletedResponse(sseChunk);
-          if (completed) {
+        const completed = captureCompletedResponse(sseChunk) as typeof completedExternalResponse.current;
+        if (completed) {
+          completedExternalResponse.current = completed;
+          if (debug) {
             appendCodexBodyDump({
               ts: new Date().toISOString(),
               transport: 'ws',
@@ -1262,8 +1304,32 @@ export async function startCodexProxy(
             provider: route.providerId ?? 'relay', routeModel: route.modelId,
             upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
           });
+          completedExternalResponse.current = undefined;
           try {
-            const routedBody = await prepareExternalCodexBody(body, {
+            const previousResponseId = typeof body.previous_response_id === 'string'
+              ? body.previous_response_id
+              : undefined;
+            const previousInput = previousResponseId
+              ? externalResponseStates.get(previousResponseId)
+              : undefined;
+            if (
+              previousResponseId
+              && !previousInput
+              && responsesInputNeedsPreviousState(body.input)
+            ) {
+              writeResponsesErrorStream(
+                modelId,
+                'Unknown or expired previous_response_id for tool continuation',
+                sendWsEvent,
+                400,
+              );
+              externalActive = false;
+              return;
+            }
+            const continuedBody = previousInput
+              ? { ...body, input: [...previousInput, ...responsesInputItems(body.input)] }
+              : body;
+            const routedBody = await prepareExternalCodexBody(continuedBody, {
               relay: nativePayloadRelay,
               mixedNative,
               headers: req.headers,
@@ -1313,6 +1379,23 @@ export async function startCodexProxy(
                 log(`WS response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
               }
             });
+            const completed = readCompletedExternalResponse();
+            if (
+              completed?.status === 'completed'
+              && typeof completed.id === 'string'
+              && Array.isArray(completed.output)
+            ) {
+              externalResponseStates.set(completed.id, [
+                ...responsesInputItems(routedBody.input),
+                ...completed.output,
+              ]);
+              if (previousResponseId) externalResponseStates.delete(previousResponseId);
+              while (externalResponseStates.size > MAX_EXTERNAL_RESPONSE_STATES_PER_SOCKET) {
+                const oldest = externalResponseStates.keys().next().value;
+                if (typeof oldest !== 'string') break;
+                externalResponseStates.delete(oldest);
+              }
+            }
             audit({
               transport: 'ws', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
               provider: route.providerId ?? 'relay', routeModel: route.modelId,

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -18,6 +18,60 @@ import { buildCompactionResponseBody, type CodexSdkCallParams } from '../src/cod
 import { CODEX_APP_AUTO_COMPACT_RATIO } from '../src/codex/app-profile.js';
 import { WebSocket, WebSocketServer } from 'ws';
 
+function openAiCompatibleTextStream(id: string, text: string, created: number): string {
+  return [
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'relay-upstream',
+      choices: [{ index: 0, delta: { role: 'assistant', content: text }, finish_reason: null }],
+    })}`,
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'relay-upstream',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    })}`,
+    'data: [DONE]',
+    '',
+  ].join('\n\n');
+}
+
+function openAiCompatibleToolStream(id: string, callId: string): string {
+  return [
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'relay-upstream',
+      choices: [{
+        index: 0,
+        delta: {
+          role: 'assistant',
+          tool_calls: [{
+            index: 0,
+            id: callId,
+            type: 'function',
+            function: { name: 'run_shell', arguments: '{"command":"pwd"}' },
+          }],
+        },
+        finish_reason: null,
+      }],
+    })}`,
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'relay-upstream',
+      choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+    })}`,
+    'data: [DONE]',
+    '',
+  ].join('\n\n');
+}
+
 describe('external Codex runtime identity', () => {
   it('distinguishes the selected external model from the Codex host', () => {
     const params = applyExternalCodexRuntimeIdentity({
@@ -520,6 +574,202 @@ describe('startCodexProxy', () => {
       expect(providerCalls).toBe(1);
     } finally {
       releaseFirst();
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
+  it('continues an external tool turn from previous_response_id and function_call_output', async () => {
+    const providerBodies: Array<{ messages?: Array<{ role?: string }> }> = [];
+    const provider = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.once('end', () => {
+        providerBodies.push(JSON.parse(Buffer.concat(chunks).toString('utf8')) as { messages?: Array<{ role?: string }> });
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        if (providerBodies.length === 1) {
+          res.end(openAiCompatibleToolStream('chatcmpl-tool', 'provider-call-1'));
+        } else {
+          res.end(openAiCompatibleTextStream('chatcmpl-final', 'FINAL_TOOL_OK', 2));
+        }
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => {
+      provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port));
+    });
+
+    handle = await startCodexProxy([{
+      modelId: 'provider__relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-upstream',
+      providerId: 'provider',
+    }], { requireAuth: false });
+
+    const tools = [{
+      type: 'function',
+      name: 'run_shell',
+      description: 'Run one shell command',
+      parameters: {
+        type: 'object',
+        properties: { command: { type: 'string' } },
+        required: ['command'],
+        additionalProperties: false,
+      },
+      strict: true,
+    }];
+
+    try {
+      const finalText = await new Promise<string>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/v1/responses`);
+        const timer = setTimeout(() => {
+          client.close();
+          reject(new Error('timed out waiting for external post-tool continuation'));
+        }, 5000);
+        let responseCount = 0;
+        client.on('open', () => {
+          client.send(JSON.stringify({
+            type: 'response.create',
+            model: 'provider__relay-model',
+            input: 'Run pwd, then report completion.',
+            tools,
+            stream: true,
+          }));
+        });
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as {
+            type?: string;
+            response?: {
+              id?: string;
+              output?: Array<{
+                type?: string;
+                call_id?: string;
+                content?: Array<{ type?: string; text?: string }>;
+              }>;
+            };
+          };
+          if (event.type !== 'response.completed') return;
+          responseCount += 1;
+          if (responseCount === 1) {
+            const call = event.response?.output?.find(item => item.type === 'function_call');
+            if (!event.response?.id || !call?.call_id) {
+              client.close();
+              reject(new Error('first response did not contain a callable function result'));
+              return;
+            }
+            client.send(JSON.stringify({
+              type: 'response.create',
+              model: 'provider__relay-model',
+              previous_response_id: event.response.id,
+              input: [{ type: 'function_call_output', call_id: call.call_id, output: '/tmp/project' }],
+              tools,
+              stream: true,
+            }));
+            return;
+          }
+          const message = event.response?.output?.find(item => item.type === 'message');
+          const text = message?.content?.find(part => part.type === 'output_text')?.text ?? '';
+          clearTimeout(timer);
+          client.close();
+          resolve(text);
+        });
+        client.on('error', reject);
+      });
+
+      expect(finalText).toBe('FINAL_TOOL_OK');
+      expect(providerBodies).toHaveLength(2);
+      expect(providerBodies[1]?.messages?.map(message => message.role).slice(-3)).toEqual([
+        'user',
+        'assistant',
+        'tool',
+      ]);
+    } finally {
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
+  it('rejects an unknown previous_response_id without contacting the provider', async () => {
+    let providerCalls = 0;
+    const provider = createServer((req, res) => {
+      providerCalls += 1;
+      req.resume();
+      req.once('end', () => {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end(openAiCompatibleTextStream('chatcmpl-standalone', 'STANDALONE_OK', 1));
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => {
+      provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port));
+    });
+
+    handle = await startCodexProxy([{
+      modelId: 'provider__relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-upstream',
+      providerId: 'provider',
+    }], { requireAuth: false });
+
+    try {
+      const status = await new Promise<string>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/v1/responses`);
+        const timer = setTimeout(() => {
+          client.close();
+          reject(new Error('timed out waiting for unknown previous_response_id rejection'));
+        }, 5000);
+        client.on('open', () => {
+          client.send(JSON.stringify({
+            type: 'response.create',
+            model: 'provider__relay-model',
+            previous_response_id: 'resp_missing',
+            input: [{ type: 'function_call_output', call_id: 'call_missing', output: 'result' }],
+            stream: true,
+          }));
+        });
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as {
+            type?: string;
+            response?: { status?: string };
+          };
+          if (event.type !== 'response.completed') return;
+          clearTimeout(timer);
+          client.close();
+          resolve(event.response?.status ?? 'unknown');
+        });
+        client.on('error', reject);
+      });
+
+      expect(status).toBe('failed');
+      expect(providerCalls).toBe(0);
+
+      const standaloneText = await new Promise<string>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/v1/responses`);
+        client.on('open', () => {
+          client.send(JSON.stringify({
+            type: 'response.create',
+            model: 'provider__relay-model',
+            previous_response_id: 'resp_missing',
+            input: 'Start a self-contained turn.',
+            stream: true,
+          }));
+        });
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as {
+            type?: string;
+            response?: { output?: Array<{ type?: string; content?: Array<{ type?: string; text?: string }> }> };
+          };
+          if (event.type !== 'response.completed') return;
+          const message = event.response?.output?.find(item => item.type === 'message');
+          const text = message?.content?.find(part => part.type === 'output_text')?.text ?? '';
+          client.close();
+          resolve(text);
+        });
+        client.on('error', reject);
+      });
+      expect(standaloneText).toBe('STANDALONE_OK');
+      expect(providerCalls).toBe(1);
+    } finally {
       await new Promise<void>(resolve => provider.close(() => resolve()));
     }
   });


### PR DESCRIPTION
## What changed?

Relay now retains a bounded successful-response history per external downstream WebSocket and reconstructs a matching `previous_response_id` continuation before translating it to the external provider. This restores the standard Responses tool loop: user request, assistant function call, tool result, and final assistant message.

Unknown or expired IDs fail only when the new input contains an orphaned tool output that requires missing state. Self-contained input remains routable, including during provider/model switches.

## Scope

- [x] This PR contains one focused fix: external WebSocket tool continuation state.
- [x] It is based directly on `881cac4`, which landed the persistent external WebSocket lifecycle tracked in #55.
- [x] It is below the maintainer-discussion size threshold.
- [x] Native forwarding, HTTP Responses, provider credentials, model routing, PR #53, dependencies, UI, and generated `dist` output are excluded.
- [x] The required proxy/networking issue is #57.

Closes #57.

Intended files:

- `src/codex-proxy.ts`
- `tests/codex-proxy.test.ts`

## Validation

- [x] Frozen red test reproduced a second provider request containing only the `tool` role.
- [x] Clean `npm ci` succeeds; this PR changes no dependencies. The existing audit result is `1 low`, `1 high`.
- [x] Focused proxy suite on `881cac4`: `45 passed`.
- [x] `npm run typecheck` passes.
- [x] Full clean suite on `881cac4`: `1,681 passed`, `8 skipped`, zero failures.
- [x] `npm run build` passes.
- [x] Isolated `npm pack` installation reports Relay `0.9.5`; tarball SHA-256 is `5221b1052a87261c929d8ba966c064a728951b79976c160bedac975e0200f3b6`.
- [x] Exact-current-head provider fixtures exercise the complete two-request function-call loop and missing-state boundary.
- [x] The equivalent continuation path was previously live-proven in ChatGPT/Codex: `pwd` executed exactly once, final assistant message `RELAY_TOOL_OK` persisted, and no `responses_retry` or disconnected-stream warning occurred.
- [x] The active ChatGPT app was not restarted solely to repeat that live proof; final installed-integration validation remains a separate rollout step.
- [x] No UI or user-facing documentation change is required.

## Risks and limitations

- State is per WebSocket and capped at eight successful responses.
- A successful continuation replaces its consumed predecessor; oldest unconsumed states are evicted at the cap.
- Unknown/expired state is rejected only for orphaned tool-output input, without contacting the provider.
- Self-contained input with an unknown/foreign ID falls back to ordinary stateless translation.
- The state is memory-only and disappears when the socket closes.
- HTTP Responses continuation remains outside this PR.

Official Responses function-calling flow: https://developers.openai.com/api/docs/guides/function-calling/
