### PR TITLE
fix(codex-proxy): preserve WebSocket turn context

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -3825,10 +3825,33 @@ function captureCompletedResponse(sseText) {
   if (!dataLine) return void 0;
   try {
     const obj = JSON.parse(dataLine.slice(5).trim());
-    if (obj && obj.type === "response.completed") return obj.response;
+    if (obj && obj.type === "response.completed" && obj.response && typeof obj.response === "object") {
+      return obj.response;
+    }
   } catch {
   }
   return void 0;
+}
+var MAX_EXTERNAL_RESPONSE_STATES = 8;
+var EXTERNAL_TOOL_OUTPUT_TYPES = /* @__PURE__ */ new Set([
+  "function_call_output",
+  "custom_tool_call_output",
+  "tool_search_output"
+]);
+function responsesInputItems(input) {
+  if (Array.isArray(input)) return input;
+  if (typeof input === "string") {
+    return [{ type: "message", role: "user", content: input }];
+  }
+  return [];
+}
+function isExternalToolOutputItem(item) {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+  const type = item.type;
+  return typeof type === "string" && EXTERNAL_TOOL_OUTPUT_TYPES.has(type);
+}
+function isExternalToolContinuation(input) {
+  return Array.isArray(input) && input.length > 0 && input.every(isExternalToolOutputItem);
 }
 function estimateCodexRequestChars(params) {
   let chars = (params.system ?? "").length;
@@ -4595,8 +4618,38 @@ Sec-WebSocket-Accept: ${wsAcceptKey(clientKey)}\r
       let externalActive = false;
       let nativeActive = false;
       let nativeUpstream;
+      let nativeSendTurn;
       let socketClosing = false;
+      const externalResponseStates = /* @__PURE__ */ new Map();
+      let currentExternalCompletedResponse;
+      let currentExternalStateInput;
+      let currentExternalConsumedResponseId;
       let currentRequestModel = "";
+      const rememberExternalResponse = (response, input) => {
+        const responseId = typeof response.id === "string" ? response.id : void 0;
+        const output = Array.isArray(response.output) ? response.output : void 0;
+        if (!responseId || !output || response.error) return;
+        externalResponseStates.delete(responseId);
+        externalResponseStates.set(responseId, { input: [...input], output: [...output] });
+        while (externalResponseStates.size > MAX_EXTERNAL_RESPONSE_STATES) {
+          const oldest = externalResponseStates.keys().next().value;
+          if (!oldest) break;
+          externalResponseStates.delete(oldest);
+        }
+      };
+      const resolveExternalContinuation = (body) => {
+        const previousResponseId = typeof body.previous_response_id === "string" ? body.previous_response_id : void 0;
+        if (!previousResponseId || !isExternalToolContinuation(body.input)) return { body };
+        const previous = externalResponseStates.get(previousResponseId);
+        if (!previous) return { body, orphanedResponseId: previousResponseId };
+        return {
+          body: {
+            ...body,
+            input: [...previous.input, ...previous.output, ...body.input]
+          },
+          consumedResponseId: previousResponseId
+        };
+      };
       const closeSocket = (code = 1e3) => {
         if (socketClosing || socket.destroyed) return;
         socketClosing = true;
@@ -4605,9 +4658,10 @@ Sec-WebSocket-Accept: ${wsAcceptKey(clientKey)}\r
       };
       const sendWsEvent = (sseChunk2) => {
         if (socketClosing || socket.destroyed) return;
-        if (debug) {
-          const completed = captureCompletedResponse(sseChunk2);
-          if (completed) {
+        const completed = captureCompletedResponse(sseChunk2);
+        if (completed) {
+          currentExternalCompletedResponse = completed;
+          if (debug) {
             appendCodexBodyDump({
               ts: (/* @__PURE__ */ new Date()).toISOString(),
               transport: "ws",
@@ -4730,7 +4784,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                 if (nativeActive && nativeUpstream) {
                   if (nativeUpstream.readyState === WebSocket.OPEN) {
                     if (debug) log14(`WS native forwarding next turn: model=${modelId}`);
-                    nativeUpstream.send(JSON.stringify({ type: "response.create", ...nativeBody }));
+                    nativeSendTurn?.(nativeBody, modelId);
                   } else if (debug) {
                     log14(`WS native cannot forward next turn: upstream_state=${nativeUpstream.readyState}`);
                   }
@@ -4741,6 +4795,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                 let upstream;
                 let nativeOpened = false;
                 let nativeCompleted = false;
+                let nativeTurnModelId = modelId;
                 let nativeFrameCount = 0;
                 let finished = false;
                 let connectTimer;
@@ -4760,20 +4815,21 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                   if (finished) return;
                   finished = true;
                   nativeActive = false;
+                  nativeSendTurn = void 0;
                   if (nativeUpstream === upstream) nativeUpstream = void 0;
                   clearTimers();
                   if (debug && message) {
-                    log14(`WS native upstream failed: model=${modelId} opened=${nativeOpened} frames=${nativeFrameCount} message=${message}`);
+                    log14(`WS native upstream failed: model=${nativeTurnModelId} opened=${nativeOpened} frames=${nativeFrameCount} message=${message}`);
                   }
                   if (message && !nativeCompleted) {
                     audit({
                       transport: "ws",
-                      requestedModel: modelId,
+                      requestedModel: nativeTurnModelId,
                       dispatch: "native",
                       phase: "complete",
                       provider: "openai-native",
-                      routeModel: modelId,
-                      upstreamModel: modelId,
+                      routeModel: nativeTurnModelId,
+                      upstreamModel: nativeTurnModelId,
                       outcome: "error",
                       status: "upstream-failed"
                     });
@@ -4785,20 +4841,31 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                   }
                   closeSocket(closeCode);
                 };
+                const sendNativeTurn = (turnBody, turnModelId) => {
+                  if (!upstream || upstream.readyState !== WebSocket.OPEN) {
+                    if (debug) log14(`WS native cannot send turn: model=${turnModelId} upstream_state=${upstream?.readyState ?? "missing"}`);
+                    return;
+                  }
+                  nativeTurnModelId = turnModelId;
+                  nativeCompleted = false;
+                  if (firstFrameTimer) clearTimeout(firstFrameTimer);
+                  upstream.send(JSON.stringify({ type: "response.create", ...turnBody }));
+                  firstFrameTimer = setTimeout(() => closeBoth("Native Codex WebSocket response timed out"), 6e4);
+                };
                 try {
                   if (debug) {
                     log14(`WS native connecting: model=${modelId} url=${target.url} headers=[${Object.keys(target.headers).join(",")}]`);
                   }
                   upstream = new WebSocket(target.url, { headers: target.headers });
                   nativeUpstream = upstream;
+                  nativeSendTurn = sendNativeTurn;
                   nativeActive = true;
                   connectTimer = setTimeout(() => closeBoth("Native Codex WebSocket connection timed out"), 15e3);
                   upstream.once("open", () => {
                     nativeOpened = true;
                     if (connectTimer) clearTimeout(connectTimer);
                     if (debug) log14(`WS native upstream open: model=${modelId}`);
-                    upstream?.send(JSON.stringify({ type: "response.create", ...nativeBody }));
-                    firstFrameTimer = setTimeout(() => closeBoth("Native Codex WebSocket response timed out"), 6e4);
+                    sendNativeTurn(nativeBody, modelId);
                   });
                   upstream.once("unexpected-response", (_request, response) => {
                     if (debug) log14(`WS native upstream HTTP rejection: model=${modelId} status=${response.statusCode}`);
@@ -4847,6 +4914,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}`, type: "i
                     if (debug) log14(`WS native downstream close: model=${modelId} frames=${nativeFrameCount} completed=${nativeCompleted}`);
                     finished = true;
                     nativeActive = false;
+                    nativeSendTurn = void 0;
                     if (nativeUpstream === upstream) nativeUpstream = void 0;
                     clearTimers();
                     try {
@@ -4890,12 +4958,24 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
             routeModel: route.modelId,
             upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId
           });
+          currentExternalCompletedResponse = void 0;
+          currentExternalStateInput = void 0;
+          currentExternalConsumedResponseId = void 0;
+          const continuation = resolveExternalContinuation(body);
+          if (continuation.orphanedResponseId) {
+            if (debug) log14(`WS continuation rejected: unknown previous_response_id=${continuation.orphanedResponseId}`);
+            writeResponsesErrorStream(modelId, "Unknown or expired previous_response_id", sendWsEvent, 400);
+            externalActive = false;
+            return;
+          }
           try {
-            const routedBody = await prepareExternalCodexBody(body, {
+            const routedBody = await prepareExternalCodexBody(continuation.body, {
               relay: nativePayloadRelay,
               mixedNative,
               headers: req.headers
             });
+            currentExternalStateInput = responsesInputItems(routedBody.input);
+            currentExternalConsumedResponseId = continuation.consumedResponseId;
             let params = applyClaudeCodeOAuthIdentity(route, applyExternalCodexRuntimeIdentity(translateResponsesRequest(
               routedBody,
               route.npm,
@@ -4941,6 +5021,12 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
                   log14(`WS response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
                 }
               });
+            if (currentExternalCompletedResponse && currentExternalStateInput) {
+              if (currentExternalConsumedResponseId) {
+                externalResponseStates.delete(currentExternalConsumedResponseId);
+              }
+              rememberExternalResponse(currentExternalCompletedResponse, currentExternalStateInput);
+            }
             audit({
               transport: "ws",
               requestedModel: modelId,
@@ -4977,6 +5063,7 @@ data: ${JSON.stringify({ error: { message: `Unknown model: ${modelId}` } })}
         })();
       };
       socket.on("error", () => socket.destroy());
+      socket.once("close", () => externalResponseStates.clear());
       socket.on("data", onData);
       onData(head);
     });

--- a/src/codex-proxy.ts
+++ b/src/codex-proxy.ts
@@ -25,6 +25,7 @@ import {
   streamCompactionResponse,
   generateCompactionResponse,
   type CodexSdkCallParams,
+  type ResponsesInputItem,
 } from './codex-responses-adapter.js';
 import { silenceSdkWarnings } from './sdk-adapter.js';
 import { formatUpstreamError, upstreamHttpStatus } from './codex/upstream-error.js';
@@ -45,17 +46,49 @@ import { appendCodexRouteAudit } from './codex/route-audit.js';
  * (see codex-responses-adapter.ts's `emit`/`sseChunk`), so no cross-call buffering
  * is needed here.
  */
-function captureCompletedResponse(sseText: string): unknown | undefined {
+function captureCompletedResponse(sseText: string): Record<string, unknown> | undefined {
   if (!sseText.includes('response.completed')) return undefined;
   const dataLine = sseText.split('\n').find(l => l.startsWith('data:'));
   if (!dataLine) return undefined;
   try {
     const obj = JSON.parse(dataLine.slice(5).trim()) as { type?: string; response?: unknown };
-    if (obj && obj.type === 'response.completed') return obj.response;
+    if (obj && obj.type === 'response.completed' && obj.response && typeof obj.response === 'object') {
+      return obj.response as Record<string, unknown>;
+    }
   } catch {
     // ignore — not our event to parse
   }
   return undefined;
+}
+
+const MAX_EXTERNAL_RESPONSE_STATES = 8;
+const EXTERNAL_TOOL_OUTPUT_TYPES = new Set([
+  'function_call_output',
+  'custom_tool_call_output',
+  'tool_search_output',
+]);
+
+interface ExternalResponseState {
+  input: ResponsesInputItem[];
+  output: ResponsesInputItem[];
+}
+
+function responsesInputItems(input: unknown): ResponsesInputItem[] {
+  if (Array.isArray(input)) return input as ResponsesInputItem[];
+  if (typeof input === 'string') {
+    return [{ type: 'message', role: 'user', content: input }];
+  }
+  return [];
+}
+
+function isExternalToolOutputItem(item: unknown): boolean {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+  const type = (item as { type?: unknown }).type;
+  return typeof type === 'string' && EXTERNAL_TOOL_OUTPUT_TYPES.has(type);
+}
+
+function isExternalToolContinuation(input: unknown): input is ResponsesInputItem[] {
+  return Array.isArray(input) && input.length > 0 && input.every(isExternalToolOutputItem);
 }
 
 export function estimateCodexRequestChars(params: CodexSdkCallParams): number {
@@ -987,10 +1020,49 @@ export async function startCodexProxy(
       let externalActive = false;
       let nativeActive = false;
       let nativeUpstream: WebSocket | undefined;
+      let nativeSendTurn: ((body: Record<string, unknown>, modelId: string) => void) | undefined;
       let socketClosing = false;
+      const externalResponseStates = new Map<string, ExternalResponseState>();
+      let currentExternalCompletedResponse: Record<string, unknown> | undefined;
+      let currentExternalStateInput: ResponsesInputItem[] | undefined;
+      let currentExternalConsumedResponseId: string | undefined;
       // Set once the request body is parsed, below — sendWsEvent is defined before
       // that point but needs the model id for its own debug dump.
       let currentRequestModel = '';
+
+      const rememberExternalResponse = (
+        response: Record<string, unknown>,
+        input: ResponsesInputItem[],
+      ) => {
+        const responseId = typeof response.id === 'string' ? response.id : undefined;
+        const output = Array.isArray(response.output) ? response.output as ResponsesInputItem[] : undefined;
+        if (!responseId || !output || response.error) return;
+        externalResponseStates.delete(responseId);
+        externalResponseStates.set(responseId, { input: [...input], output: [...output] });
+        while (externalResponseStates.size > MAX_EXTERNAL_RESPONSE_STATES) {
+          const oldest = externalResponseStates.keys().next().value as string | undefined;
+          if (!oldest) break;
+          externalResponseStates.delete(oldest);
+        }
+      };
+
+      const resolveExternalContinuation = (
+        body: Record<string, unknown>,
+      ): { body: Record<string, unknown>; consumedResponseId?: string; orphanedResponseId?: string } => {
+        const previousResponseId = typeof body.previous_response_id === 'string'
+          ? body.previous_response_id
+          : undefined;
+        if (!previousResponseId || !isExternalToolContinuation(body.input)) return { body };
+        const previous = externalResponseStates.get(previousResponseId);
+        if (!previous) return { body, orphanedResponseId: previousResponseId };
+        return {
+          body: {
+            ...body,
+            input: [...previous.input, ...previous.output, ...body.input],
+          },
+          consumedResponseId: previousResponseId,
+        };
+      };
 
       const closeSocket = (code = 1000) => {
         if (socketClosing || socket.destroyed) return;
@@ -1001,9 +1073,10 @@ export async function startCodexProxy(
 
       const sendWsEvent = (sseChunk: string) => {
         if (socketClosing || socket.destroyed) return;
-        if (debug) {
-          const completed = captureCompletedResponse(sseChunk);
-          if (completed) {
+        const completed = captureCompletedResponse(sseChunk);
+        if (completed) {
+          currentExternalCompletedResponse = completed;
+          if (debug) {
             appendCodexBodyDump({
               ts: new Date().toISOString(),
               transport: 'ws',
@@ -1123,7 +1196,7 @@ export async function startCodexProxy(
                 if (nativeActive && nativeUpstream) {
                   if (nativeUpstream.readyState === WebSocket.OPEN) {
                     if (debug) log(`WS native forwarding next turn: model=${modelId}`);
-                    nativeUpstream.send(JSON.stringify({ type: 'response.create', ...nativeBody }));
+                    nativeSendTurn?.(nativeBody, modelId);
                   } else if (debug) {
                     log(`WS native cannot forward next turn: upstream_state=${nativeUpstream.readyState}`);
                   }
@@ -1136,6 +1209,7 @@ export async function startCodexProxy(
                 let upstream: WebSocket | undefined;
                 let nativeOpened = false;
                 let nativeCompleted = false;
+                let nativeTurnModelId = modelId;
                 let nativeFrameCount = 0;
                 let finished = false;
                 let connectTimer: NodeJS.Timeout | undefined;
@@ -1155,15 +1229,16 @@ export async function startCodexProxy(
                   if (finished) return;
                   finished = true;
                   nativeActive = false;
+                  nativeSendTurn = undefined;
                   if (nativeUpstream === upstream) nativeUpstream = undefined;
                   clearTimers();
                   if (debug && message) {
-                    log(`WS native upstream failed: model=${modelId} opened=${nativeOpened} frames=${nativeFrameCount} message=${message}`);
+                    log(`WS native upstream failed: model=${nativeTurnModelId} opened=${nativeOpened} frames=${nativeFrameCount} message=${message}`);
                   }
                   if (message && !nativeCompleted) {
                     audit({
-                      transport: 'ws', requestedModel: modelId, dispatch: 'native', phase: 'complete',
-                      provider: 'openai-native', routeModel: modelId, upstreamModel: modelId,
+                      transport: 'ws', requestedModel: nativeTurnModelId, dispatch: 'native', phase: 'complete',
+                      provider: 'openai-native', routeModel: nativeTurnModelId, upstreamModel: nativeTurnModelId,
                       outcome: 'error', status: 'upstream-failed',
                     });
                   }
@@ -1171,20 +1246,31 @@ export async function startCodexProxy(
                   try { upstream?.close(); } catch { /* ignore */ }
                   closeSocket(closeCode);
                 };
+                const sendNativeTurn = (turnBody: Record<string, unknown>, turnModelId: string) => {
+                  if (!upstream || upstream.readyState !== WebSocket.OPEN) {
+                    if (debug) log(`WS native cannot send turn: model=${turnModelId} upstream_state=${upstream?.readyState ?? 'missing'}`);
+                    return;
+                  }
+                  nativeTurnModelId = turnModelId;
+                  nativeCompleted = false;
+                  if (firstFrameTimer) clearTimeout(firstFrameTimer);
+                  upstream.send(JSON.stringify({ type: 'response.create', ...turnBody }));
+                  firstFrameTimer = setTimeout(() => closeBoth('Native Codex WebSocket response timed out'), 60_000);
+                };
                 try {
                   if (debug) {
                     log(`WS native connecting: model=${modelId} url=${target.url} headers=[${Object.keys(target.headers).join(',')}]`);
                   }
                   upstream = new WebSocket(target.url, { headers: target.headers });
                   nativeUpstream = upstream;
+                  nativeSendTurn = sendNativeTurn;
                   nativeActive = true;
                   connectTimer = setTimeout(() => closeBoth('Native Codex WebSocket connection timed out'), 15_000);
                   upstream.once('open', () => {
                     nativeOpened = true;
                     if (connectTimer) clearTimeout(connectTimer);
                     if (debug) log(`WS native upstream open: model=${modelId}`);
-                    upstream?.send(JSON.stringify({ type: 'response.create', ...nativeBody }));
-                    firstFrameTimer = setTimeout(() => closeBoth('Native Codex WebSocket response timed out'), 60_000);
+                    sendNativeTurn(nativeBody, modelId);
                   });
                   upstream.once('unexpected-response', (_request, response) => {
                     if (debug) log(`WS native upstream HTTP rejection: model=${modelId} status=${response.statusCode}`);
@@ -1228,6 +1314,7 @@ export async function startCodexProxy(
                     if (debug) log(`WS native downstream close: model=${modelId} frames=${nativeFrameCount} completed=${nativeCompleted}`);
                     finished = true;
                     nativeActive = false;
+                    nativeSendTurn = undefined;
                     if (nativeUpstream === upstream) nativeUpstream = undefined;
                     clearTimers();
                     try { upstream?.close(); } catch { /* ignore */ }
@@ -1262,12 +1349,24 @@ export async function startCodexProxy(
             provider: route.providerId ?? 'relay', routeModel: route.modelId,
             upstreamModel: route.auditUpstreamModelId ?? route.upstreamModelId,
           });
+          currentExternalCompletedResponse = undefined;
+          currentExternalStateInput = undefined;
+          currentExternalConsumedResponseId = undefined;
+          const continuation = resolveExternalContinuation(body);
+          if (continuation.orphanedResponseId) {
+            if (debug) log(`WS continuation rejected: unknown previous_response_id=${continuation.orphanedResponseId}`);
+            writeResponsesErrorStream(modelId, 'Unknown or expired previous_response_id', sendWsEvent, 400);
+            externalActive = false;
+            return;
+          }
           try {
-            const routedBody = await prepareExternalCodexBody(body, {
+            const routedBody = await prepareExternalCodexBody(continuation.body, {
               relay: nativePayloadRelay,
               mixedNative,
               headers: req.headers,
             });
+            currentExternalStateInput = responsesInputItems(routedBody.input);
+            currentExternalConsumedResponseId = continuation.consumedResponseId;
             let params = applyClaudeCodeOAuthIdentity(route, applyExternalCodexRuntimeIdentity(translateResponsesRequest(
               routedBody as unknown as import('./codex-responses-adapter.js').ResponsesRequest,
               route.npm,
@@ -1313,6 +1412,12 @@ export async function startCodexProxy(
                 log(`WS response progress: model=${route.modelId} elapsedMs=${progress.elapsedMs} reasoningChars=${progress.reasoningChars} textChars=${progress.textChars} toolCalls=${progress.toolCallCount} reasoningTail=${JSON.stringify(progress.reasoningTail)}`);
               }
             });
+            if (currentExternalCompletedResponse && currentExternalStateInput) {
+              if (currentExternalConsumedResponseId) {
+                externalResponseStates.delete(currentExternalConsumedResponseId);
+              }
+              rememberExternalResponse(currentExternalCompletedResponse, currentExternalStateInput);
+            }
             audit({
               transport: 'ws', requestedModel: modelId, dispatch: relayDispatch, phase: 'complete',
               provider: route.providerId ?? 'relay', routeModel: route.modelId,
@@ -1338,6 +1443,7 @@ export async function startCodexProxy(
       };
 
       socket.on('error', () => socket.destroy());
+      socket.once('close', () => externalResponseStates.clear());
       socket.on('data', onData);
       onData(head);
     });

--- a/tests/codex-proxy.test.ts
+++ b/tests/codex-proxy.test.ts
@@ -400,6 +400,58 @@ describe('startCodexProxy', () => {
     }
   });
 
+  it('reports a later native turn that closes before completion', async () => {
+    const upstream = new WebSocketServer({ port: 0 });
+    const upstreamPort = await new Promise<number>(resolve => upstream.on('listening', () => resolve((upstream.address() as { port: number }).port)));
+    const received: Record<string, unknown>[] = [];
+    upstream.on('connection', socket => {
+      socket.on('message', data => {
+        const body = JSON.parse(data.toString()) as Record<string, unknown>;
+        received.push(body);
+        if (received.length === 1) {
+          socket.send(JSON.stringify({ type: 'response.completed', response: { status: 'completed' } }));
+        } else {
+          socket.close(1011, 'later turn failed');
+        }
+      });
+    });
+    const capability = 'H'.repeat(43);
+    handle = await startCodexProxy([], {
+      requireAuth: false,
+      mixedNative: { nativeModelIds: new Set(['gpt-5.5']), capability, nativeBaseUrl: `http://127.0.0.1:${upstreamPort}` },
+    });
+    try {
+      const result = await new Promise<{ closeCode: number; errors: Record<string, unknown>[] }>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`);
+        const errors: Record<string, unknown>[] = [];
+        const timer = setTimeout(() => { client.close(); reject(new Error('timed out waiting for later native turn failure')); }, 3_000);
+        let completed = 0;
+        client.on('open', () => client.send(JSON.stringify({ model: 'gpt-5.5', input: 'first' })));
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as Record<string, unknown>;
+          if (event.type === 'response.completed') {
+            completed += 1;
+            if (completed === 1) client.send(JSON.stringify({ model: 'gpt-5.5', input: 'second' }));
+          }
+          if (event.type === 'error') errors.push(event);
+        });
+        client.on('close', closeCode => { clearTimeout(timer); resolve({ closeCode, errors }); });
+        client.on('error', reject);
+      });
+      expect(received).toHaveLength(2);
+      expect(result.closeCode).toBe(1011);
+      expect(result.errors).toContainEqual(expect.objectContaining({
+        type: 'error',
+        error: expect.objectContaining({
+          type: 'upstream_error',
+          message: 'Native Codex WebSocket closed before completion (1011)',
+        }),
+      }));
+    } finally {
+      await new Promise<void>(resolve => upstream.close(() => resolve()));
+    }
+  });
+
   it('keeps an external WebSocket open for sequential response.create turns', async () => {
     const requestBodies: Record<string, unknown>[] = [];
     const provider = createServer((req, res) => {
@@ -462,6 +514,161 @@ describe('startCodexProxy', () => {
       expect(requestBodies).toHaveLength(2);
       expect(JSON.stringify(requestBodies[0])).toContain('first');
       expect(JSON.stringify(requestBodies[1])).toContain('second');
+    } finally {
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
+  it('reconstructs an external tool continuation from previous_response_id', async () => {
+    const requestBodies: Record<string, unknown>[] = [];
+    const provider = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.once('end', () => {
+        requestBodies.push(JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>);
+        const turn = requestBodies.length;
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        if (turn === 1) {
+          res.write(`data: ${JSON.stringify({
+            id: 'chatcmpl-tool-call',
+            object: 'chat.completion.chunk',
+            choices: [{ index: 0, delta: {
+              role: 'assistant',
+              tool_calls: [{ index: 0, id: 'call_pwd', type: 'function', function: { name: 'shell', arguments: '{"cmd":"pwd"}' } }],
+            }, finish_reason: 'tool_calls' }],
+          })}\n\n`);
+        } else {
+          res.write(`data: ${JSON.stringify({
+            id: 'chatcmpl-final',
+            object: 'chat.completion.chunk',
+            choices: [{ index: 0, delta: { role: 'assistant', content: 'CONTINUATION_OK' }, finish_reason: null }],
+          })}\n\n`);
+          res.write(`data: ${JSON.stringify({
+            id: 'chatcmpl-final',
+            object: 'chat.completion.chunk',
+            choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+          })}\n\n`);
+        }
+        res.end('data: [DONE]\n\n');
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port)));
+    const capability = 'I'.repeat(43);
+    handle = await startCodexProxy([{
+      modelId: 'relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-model',
+      providerId: 'relay-provider',
+    }], {
+      requireAuth: false,
+      mixedNative: { nativeModelIds: new Set(['gpt-5.5']), capability },
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`);
+        const timer = setTimeout(() => { client.close(); reject(new Error('timed out waiting for external continuation')); }, 3_000);
+        let completed = 0;
+        let responseId = '';
+        client.on('open', () => client.send(JSON.stringify({
+          model: 'relay-model',
+          stream: true,
+          tools: [{ type: 'function', name: 'shell', parameters: { type: 'object' } }],
+          input: 'run pwd',
+        })));
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as { type?: string; response?: { id?: string } };
+          if (event.type !== 'response.completed') return;
+          completed += 1;
+          if (completed === 1) {
+            responseId = event.response?.id ?? '';
+            client.send(JSON.stringify({
+              model: 'relay-model',
+              stream: true,
+              previous_response_id: responseId,
+              tools: [{ type: 'function', name: 'shell', parameters: { type: 'object' } }],
+              input: [{ type: 'function_call_output', call_id: 'call_pwd', output: 'workspace' }],
+            }));
+          } else {
+            client.close();
+          }
+        });
+        client.on('close', code => {
+          clearTimeout(timer);
+          if (code !== 1000 || completed !== 2 || !responseId) {
+            reject(new Error(`external continuation failed: code=${code} completed=${completed} responseId=${responseId || '(none)'}`));
+            return;
+          }
+          resolve();
+        });
+        client.on('error', reject);
+      });
+      expect(requestBodies).toHaveLength(2);
+      const messages = requestBodies[1]!.messages as Array<{ role?: string }>;
+      expect(messages.slice(-3).map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
+      expect(JSON.stringify(requestBodies[1])).toContain('run pwd');
+      expect(JSON.stringify(requestBodies[1])).toContain('call_pwd');
+      expect(JSON.stringify(requestBodies[1])).toContain('workspace');
+    } finally {
+      await new Promise<void>(resolve => provider.close(() => resolve()));
+    }
+  });
+
+  it('rejects an orphaned external tool continuation before contacting the provider', async () => {
+    let providerCalls = 0;
+    const provider = createServer((req, res) => {
+      providerCalls += 1;
+      req.resume();
+      req.once('end', () => {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end(`data: ${JSON.stringify({
+          id: 'chatcmpl-orphan',
+          object: 'chat.completion.chunk',
+          choices: [{ index: 0, delta: { role: 'assistant', content: 'provider-was-contacted' }, finish_reason: 'stop' }],
+        })}\n\ndata: [DONE]\n\n`);
+      });
+    });
+    const providerPort = await new Promise<number>(resolve => provider.listen(0, '127.0.0.1', () => resolve((provider.address() as { port: number }).port)));
+    const capability = 'J'.repeat(43);
+    handle = await startCodexProxy([{
+      modelId: 'relay-model',
+      npm: '@ai-sdk/openai-compatible',
+      apiKey: 'test-key',
+      baseURL: `http://127.0.0.1:${providerPort}/v1`,
+      upstreamModelId: 'relay-model',
+      providerId: 'relay-provider',
+    }], {
+      requireAuth: false,
+      mixedNative: { nativeModelIds: new Set(['gpt-5.5']), capability },
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const client = new WebSocket(`ws://127.0.0.1:${handle!.port}/_relay-codex/${capability}/v1/responses`);
+        const timer = setTimeout(() => { client.close(); reject(new Error('timed out waiting for orphan rejection')); }, 3_000);
+        client.on('open', () => client.send(JSON.stringify({
+          model: 'relay-model',
+          stream: true,
+          previous_response_id: 'resp-expired',
+          input: [{ type: 'function_call_output', call_id: 'call_expired', output: 'orphan' }],
+        })));
+        client.on('message', data => {
+          const event = JSON.parse(data.toString()) as { type?: string };
+          if (event.type === 'response.completed') client.close();
+        });
+        client.on('close', code => {
+          clearTimeout(timer);
+          if (code !== 1000) {
+            reject(new Error(`orphan continuation closed unexpectedly: code=${code}`));
+            return;
+          }
+          resolve();
+        });
+        client.on('error', reject);
+      });
+      expect(providerCalls).toBe(0);
     } finally {
       await new Promise<void>(resolve => provider.close(() => resolve()));
     }


### PR DESCRIPTION
## Summary
- preserve bounded, connection-local external Responses state for `previous_response_id` tool continuations
- reject orphaned external tool continuations before contacting a provider
- reset native completion state and rearm the first-frame timeout for every persistent native turn
- retain authentication, routing, native forwarding, and HTTP behavior

## Verification
- `npm run typecheck`
- `npm test` — 1,688 passed, 2 skipped
- `npm run build`
- `git diff --check`

Closes #57
Closes #59
