### PR TITLE
fix(codex-app): identify the macOS main process safely

### DIFF
--- a/src/codex/app-launch.ts
+++ b/src/codex/app-launch.ts
@@ -241,26 +241,44 @@ export function darwinMainExecutableCandidates(appPath: string): string[] {
   return DARWIN_APP_NAMES.map(name => join(appPath, 'Contents', 'MacOS', name));
 }
 
-function pgrepExactCommand(commands: readonly string[]): number[] {
+export function darwinMainPidsFromProcessList(
+  processList: string,
+  commands: readonly string[],
+  currentPid = process.pid,
+): number[] {
   const pids = new Set<number>();
-  for (const command of commands) {
-    try {
-      const out = execFileSync('pgrep', ['-f', `^${command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`], {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-      for (const raw of out.split(/\s+/)) {
-        const pid = Number.parseInt(raw, 10);
-        if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) pids.add(pid);
-      }
-    } catch { /* exact command is not running */ }
+  for (const line of processList.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(.+?)\s*$/);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1]!, 10);
+    const command = match[2]!;
+    if (
+      Number.isFinite(pid)
+      && pid > 0
+      && pid !== currentPid
+      && commands.some(candidate => command === candidate || command.startsWith(`${candidate} `))
+    ) {
+      pids.add(pid);
+    }
   }
   return [...pids];
 }
 
 function darwinMatchingPids(): number[] {
   const appPath = findCodexApp('darwin');
-  return appPath ? pgrepExactCommand(darwinMainExecutableCandidates(appPath)) : [];
+  if (!appPath) return [];
+  try {
+    const processList = execFileSync('ps', ['-axo', 'pid=,command='], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return darwinMainPidsFromProcessList(
+      processList,
+      darwinMainExecutableCandidates(appPath),
+    );
+  } catch {
+    return [];
+  }
 }
 
 function linuxIsRunning(): boolean {

--- a/tests/codex-app-launch.test.ts
+++ b/tests/codex-app-launch.test.ts
@@ -5,6 +5,7 @@ import {
   codexAppSupported,
   darwinQuitAppleScript,
   darwinMainExecutableCandidates,
+  darwinMainPidsFromProcessList,
   linuxCodexAppCandidates,
   linuxEmbeddedCodexCandidates,
   restartTimeoutAction,
@@ -57,6 +58,19 @@ describe('ChatGPT desktop restart safety', () => {
       '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
       '/Applications/ChatGPT.app/Contents/MacOS/Codex',
     ]);
+  });
+
+  it('finds the macOS main PID when pgrep omits ChatGPT but ps reports its full command', () => {
+    const commands = darwinMainExecutableCandidates('/Applications/ChatGPT.app');
+    const processList = [
+      ' 2757 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+      ' 2773 /Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/Codex (Service) --type=gpu-process',
+      ' 3122 /Applications/ChatGPT.app/Contents/Resources/native/bare-modifier-monitor --key DoubleCommand',
+      ' 4000 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT -psn_0_12345',
+      ' 5000 /Applications/Other.app/Contents/MacOS/ChatGPT',
+    ].join('\n');
+
+    expect(darwinMainPidsFromProcessList(processList, commands, 4000)).toEqual([2757]);
   });
 
   it('targets the stable macOS bundle id instead of the deprecated Codex app name', () => {

--- a/tests/codex-app-launch.test.ts
+++ b/tests/codex-app-launch.test.ts
@@ -67,10 +67,11 @@ describe('ChatGPT desktop restart safety', () => {
       ' 2773 /Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/Codex (Service) --type=gpu-process',
       ' 3122 /Applications/ChatGPT.app/Contents/Resources/native/bare-modifier-monitor --key DoubleCommand',
       ' 4000 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT -psn_0_12345',
+      ' 4010 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT -psn_0_67890',
       ' 5000 /Applications/Other.app/Contents/MacOS/ChatGPT',
     ].join('\n');
 
-    expect(darwinMainPidsFromProcessList(processList, commands, 4000)).toEqual([2757]);
+    expect(darwinMainPidsFromProcessList(processList, commands, 4000)).toEqual([2757, 4010]);
   });
 
   it('targets the stable macOS bundle id instead of the deprecated Codex app name', () => {


### PR DESCRIPTION
## What changed?

Relay now identifies the macOS ChatGPT/Codex main PID from a single full-command process snapshot rather than relying on `pgrep -f`, which can omit the current ChatGPT main process.

Matching remains fail-closed and path-specific: only the installed app's exact main executable is accepted, optionally followed by a space-delimited launch argument. Renderer, service, monitor, crashpad, unrelated-app, and current-process entries remain excluded.

## Scope

- [x] One focused fix: macOS ChatGPT main-PID identification during restart.
- [x] Based directly on upstream `93a7be3` after merged PR #62.
- [x] macOS-only behavior; Windows and Linux launch logic are unchanged.
- [x] Proxy routing, authentication, providers, model catalogs, WebSocket behavior, dependencies, UI, and generated `dist` output are excluded.
- [x] The focused app-lifecycle issue is #63.

Closes #63.

Intended files:

- `src/codex/app-launch.ts`
- `tests/codex-app-launch.test.ts`

## Validation

- [x] Live red reproduction: ChatGPT was running, but `pgrep -f` returned no main PID and Relay refused the restart.
- [x] Clean `npm ci` succeeds; this PR changes no dependencies. The existing audit result is `1 low`, `1 high`.
- [x] Focused lifecycle suite: `15 passed`.
- [x] `npm run typecheck` passes.
- [x] `npm run build` passes.
- [x] Full suite, run after build: `1,683 passed`, `8 skipped`, zero failures.
- [x] Clean-branch live detector proof: shell main PID `7912`; detector result `[7912]`.
- [x] Isolated `npm pack` installation reports Relay `0.9.5`; tarball SHA-256 is `85d4e2873e37d893a0f3a6f5252899c12f69ff7df5f2cf50c441f67f914fa53e`.
- [x] Equivalent patch live-proven during a successful manual Relay launch: Relay PID `7708`, ChatGPT replacement PID `7912`.
- [x] No user-facing documentation change is required.

## Risks and limitations

- Process-list parsing depends on the stable macOS `ps -axo pid=,command=` format requested explicitly by Relay.
- Matching requires an exact installed executable path or that exact path followed by a space-delimited argument.
- Helper processes and unrelated applications are intentionally ignored.
- Relay still refuses to restart when the installed main executable cannot be identified.
- This does not change model availability; launchers must still use a model present in the refreshed provider catalog.
